### PR TITLE
25 normalize data on gpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ data
 │       ├── parameter_std.pt                - Std.-dev. of state parameters (create_parameter_weights.py)
 │       ├── diff_mean.pt                    - Means of one-step differences (create_parameter_weights.py)
 │       ├── diff_std.pt                     - Std.-dev. of one-step differences (create_parameter_weights.py)
-│       ├── flux_stats.pt                   - Mean and std.-dev. of solar flux forcing (create_parameter_weights.py)
+│       ├── flux_mean.pt                    - Mean of solar flux forcing (create_parameter_weights.py)
+│       ├── flux_std.pt                     - Std.-dev. of solar flux forcing (create_parameter_weights.py)
 │       └── parameter_weights.npy           - Loss weights for different state parameters (create_parameter_weights.py)
 ├── dataset2
 ├── ...

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -197,6 +197,19 @@ class ARModel(pl.LightningModule):
 
         return prediction, target_states, pred_std
 
+    def on_after_batch_transfer(self, batch, dataloader_idx):
+        """Normalize Batch data after transferring to the device."""
+        init_states, target_states, forcing_features = batch
+        init_states = (init_states - self.data_mean) / self.data_std
+        target_states = (target_states - self.data_mean) / self.data_std
+        forcing_features = (forcing_features - self.flux_mean) / self.flux_std
+        batch = (
+            init_states,
+            target_states,
+            forcing_features,
+        )
+        return batch
+
     def training_step(self, batch):
         """
         Train on single batch

--- a/neural_lam/utils.py
+++ b/neural_lam/utils.py
@@ -8,31 +8,6 @@ from torch import nn
 from tueplots import bundles, figsizes
 
 
-def load_dataset_stats(dataset_name, device="cpu"):
-    """
-    Load arrays with stored dataset statistics from pre-processing
-    """
-    static_dir_path = os.path.join("data", dataset_name, "static")
-
-    def loads_file(fn):
-        return torch.load(
-            os.path.join(static_dir_path, fn), map_location=device
-        )
-
-    data_mean = loads_file("parameter_mean.pt")  # (d_features,)
-    data_std = loads_file("parameter_std.pt")  # (d_features,)
-
-    flux_stats = loads_file("flux_stats.pt")  # (2,)
-    flux_mean, flux_std = flux_stats
-
-    return {
-        "data_mean": data_mean,
-        "data_std": data_std,
-        "flux_mean": flux_mean,
-        "flux_std": flux_std,
-    }
-
-
 def load_static_data(dataset_name, device="cpu"):
     """
     Load static files related to dataset
@@ -64,6 +39,9 @@ def load_static_data(dataset_name, device="cpu"):
     data_mean = loads_file("parameter_mean.pt")  # (d_features,)
     data_std = loads_file("parameter_std.pt")  # (d_features,)
 
+    flux_mean = loads_file("flux_mean.pt")  # (,)
+    flux_std = loads_file("flux_std.pt")  # (,)
+
     # Load loss weighting vectors
     param_weights = torch.tensor(
         np.load(os.path.join(static_dir_path, "parameter_weights.npy")),
@@ -78,6 +56,8 @@ def load_static_data(dataset_name, device="cpu"):
         "step_diff_std": step_diff_std,
         "data_mean": data_mean,
         "data_std": data_std,
+        "flux_mean": flux_mean,
+        "flux_std": flux_std,
         "param_weights": param_weights,
     }
 

--- a/neural_lam/vis.py
+++ b/neural_lam/vis.py
@@ -87,7 +87,7 @@ def plot_prediction(
         1,
         2,
         figsize=(13, 7),
-        subplot_kw={"projection": data_config.coords_projection()},
+        subplot_kw={"projection": data_config.coords_projection},
     )
 
     # Plot pred and target
@@ -136,7 +136,7 @@ def plot_spatial_error(error, obs_mask, data_config, title=None, vrange=None):
 
     fig, ax = plt.subplots(
         figsize=(5, 4.8),
-        subplot_kw={"projection": data_config.coords_projection()},
+        subplot_kw={"projection": data_config.coords_projection},
     )
 
     ax.coastlines()  # Add coastline outlines

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -7,9 +7,6 @@ import os
 import numpy as np
 import torch
 
-# First-party
-from neural_lam import utils
-
 
 class WeatherDataset(torch.utils.data.Dataset):
     """
@@ -29,7 +26,6 @@ class WeatherDataset(torch.utils.data.Dataset):
         pred_length=19,
         split="train",
         subsample_step=3,
-        standardize=True,
         subset=False,
         control_only=False,
     ):
@@ -60,17 +56,6 @@ class WeatherDataset(torch.utils.data.Dataset):
         assert (
             self.sample_length <= self.original_sample_length
         ), "Requesting too long time series samples"
-
-        # Set up for standardization
-        self.standardize = standardize
-        if standardize:
-            ds_stats = utils.load_dataset_stats(dataset_name, "cpu")
-            self.data_mean, self.data_std, self.flux_mean, self.flux_std = (
-                ds_stats["data_mean"],
-                ds_stats["data_std"],
-                ds_stats["flux_mean"],
-                ds_stats["flux_std"],
-            )
 
         # If subsample index should be sampled (only duing training)
         self.random_subsample = split == "train"
@@ -148,10 +133,6 @@ class WeatherDataset(torch.utils.data.Dataset):
         sample = sample[init_id : (init_id + self.sample_length)]
         # (sample_length, N_grid, d_features)
 
-        if self.standardize:
-            # Standardize sample
-            sample = (sample - self.data_mean) / self.data_std
-
         # Split up sample in init. states and target states
         init_states = sample[:2]  # (2, N_grid, d_features)
         target_states = sample[2:]  # (sample_length-2, N_grid, d_features)
@@ -184,9 +165,6 @@ class WeatherDataset(torch.utils.data.Dataset):
         flux = torch.tensor(np.load(flux_path), dtype=torch.float32).unsqueeze(
             -1
         )  # (N_t', dim_x, dim_y, 1)
-
-        if self.standardize:
-            flux = (flux - self.flux_mean) / self.flux_std
 
         # Flatten and subsample flux forcing
         flux = flux.flatten(1, 2)  # (N_t, N_grid, 1)


### PR DESCRIPTION
## Summary
This PR introduces `on_after_batch_transfer` logic to normalize data on GPU instead of on CPU before transfer.

### Rationale
Normalization is faster on GPU than CPU. In the current code the data was normalized in the pytorch dataset class in the __get_item__ method potentially slowing down training; especially on systems with fewer CPU cores.

### Changes
- Introduces `on_after_batch_transfer` in the `ar_model.py` script
- Remove everything related to "standardization" from the remaining scripts
- Adapted the `create_parameter_weights.py` script to work with the new changes (not reloading standardized dataset)

### Testing
Both training and evaluation was successful. The training loss of 3.230 on the meps_example is identical to before the changes. The create_parameter_weights script was executed to successfully generate the stats.

### Not-In-Scope
The normalization stats and other static features will all become zarr archives in the future. There path defined in the data_config.yaml file.