### PR TITLE
GRIB output

### DIFF
--- a/neural_lam/data_config.yaml
+++ b/neural_lam/data_config.yaml
@@ -1,5 +1,7 @@
 dataset:
   name: cosmo
+
+  # Value definitions
   var_names:
     - "T"
     - "U"
@@ -28,14 +30,41 @@ dataset:
     - 1
     - 0
     - 1
+  grib_names:
+    PP: "pres"
+    QV: "q"
+    RELHUM: "r"
+    T: "t"
+    U: "u"
+    V: "v"
+    W: "wz"
+    CLCT: "ccl"
+    PMSL: "prmsl"
+    PS: "sp"
+    T_2M: "2t"
+    TOT_PREC: "tp"
+    U_10M: "10u"
+    V_10M: "10v"
   vertical_levels: [1, 5, 13, 22, 38, 41, 60]
   num_forcing_features: 16
+
+  # Plotting 
   eval_plot_vars: ["TQV"]
-  grid_shape_state: [268, 238]
+  grid_shape_state: [390, 582]
   projection:
     class: LambertConformal
     kwargs:
       central_longitude: 15.0
       central_latitude: 63.3
       standard_parallels: [63.3, 63.3]
+  sample_grib:
+    "templates/lfff02180000"
+  sample_z_grib:
+   "templates/lfff02180000z"
+  eval_datetime:
+    ["2020100215"]
+
+  # Time step prediction during training / prediction (eval)
+  train_horizon: 3
+  eval_horizon: 25
 

--- a/neural_lam/data_config.yaml
+++ b/neural_lam/data_config.yaml
@@ -1,70 +1,5 @@
 dataset:
-  name: meps_example
-  var_names:
-    - pres_0g
-    - pres_0s
-    - nlwrs_0
-    - nswrs_0
-    - r_2
-    - r_65
-    - t_2
-    - t_65
-    - t_500
-    - t_850
-    - u_65
-    - u_850
-    - v_65
-    - v_850
-    - wvint_0
-    - z_1000
-    - z_500
-  var_units:
-    - Pa
-    - Pa
-    - r"$\mathrm{W}/\mathrm{m}^2$"
-    - r"$\mathrm{W}/\mathrm{m}^2$"
-    - ""
-    - ""
-    - K
-    - K
-    - K
-    - K
-    - m/s
-    - m/s
-    - m/s
-    - m/s
-    - r"$\mathrm{kg}/\mathrm{m}^2$"
-    - r"$\mathrm{m}^2/\mathrm{s}^2$"
-    - r"$\mathrm{m}^2/\mathrm{s}^2$"
-  var_longnames:
-    - pres_heightAboveGround_0_instant
-    - pres_heightAboveSea_0_instant
-    - nlwrs_heightAboveGround_0_accum
-    - nswrs_heightAboveGround_0_accum
-    - r_heightAboveGround_2_instant
-    - r_hybrid_65_instant
-    - t_heightAboveGround_2_instant
-    - t_hybrid_65_instant
-    - t_isobaricInhPa_500_instant
-    - t_isobaricInhPa_850_instant
-    - u_hybrid_65_instant
-    - u_isobaricInhPa_850_instant
-    - v_hybrid_65_instant
-    - v_isobaricInhPa_850_instant
-    - wvint_entireAtmosphere_0_instant
-    - z_isobaricInhPa_1000_instant
-    - z_isobaricInhPa_500_instant
-  num_forcing_features: 16
-grid_shape_state: [268, 238]
-projection:
-  class: LambertConformal
-  kwargs:
-    central_longitude: 15.0
-    central_latitude: 63.3
-    standard_parallels: [63.3, 63.3]
-
-dataset2:
-  name: cosmo_example
+  name: cosmo
   var_names:
     - "T"
     - "U"
@@ -96,3 +31,11 @@ dataset2:
   vertical_levels: [1, 5, 13, 22, 38, 41, 60]
   num_forcing_features: 16
   eval_plot_vars: ["TQV"]
+  grid_shape_state: [268, 238]
+  projection:
+    class: LambertConformal
+    kwargs:
+      central_longitude: 15.0
+      central_latitude: 63.3
+      standard_parallels: [63.3, 63.3]
+

--- a/neural_lam/data_config.yaml
+++ b/neural_lam/data_config.yaml
@@ -62,3 +62,37 @@ projection:
     central_longitude: 15.0
     central_latitude: 63.3
     standard_parallels: [63.3, 63.3]
+
+dataset2:
+  name: cosmo_example
+  var_names:
+    - "T"
+    - "U"
+    - "V"
+    - "RELHUM"
+    - "PMSL"
+    - "PP"
+  var_units:
+    - K
+    - m/s
+    - m/s
+    - Perc.
+    - Pa
+    - hPa
+  var_longnames:
+    - "Temperature"
+    - "Zonal wind component"
+    - "Meridional wind component"
+    - "Relative humidity"
+    - "Pressure at Mean Sea Level"
+    - "Pressure Perturbation"
+  var_is_3d:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 0
+    - 1
+  vertical_levels: [1, 5, 13, 22, 38, 41, 60]
+  num_forcing_features: 16
+  eval_plot_vars: ["TQV"]

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -98,7 +98,7 @@ class BaseGraphModel(ARModel):
         """
         raise NotImplementedError("process_step not implemented")
 
-    def predict_step(self, prev_state, prev_prev_state, forcing):
+    def single_prediction(self, prev_state, prev_prev_state, forcing):
         """
         Step state one step ahead using prediction model, X_{t-1}, X_t -> X_t+1
         prev_state: (B, num_grid_nodes, feature_dim), X_t

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -35,7 +35,7 @@ class WeatherDataset(torch.utils.data.Dataset):
     ):
         super().__init__()
 
-        assert split in ("train", "val", "test"), "Unknown dataset split"
+        assert split in ("train", "val", "test", "pred"), "Unknown dataset split"
         self.sample_dir_path = os.path.join(
             "data", dataset_name, "samples", split
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ Cartopy>=0.22.0
 pyproj>=3.4.1
 tueplots>=0.0.8
 plotly>=5.15.0
+earthkit-data>=0.7.0
+eccodes>=1.7.0
 
 # for dev
 pre-commit>=2.15.0


### PR DESCRIPTION
## Purpose 
This is the equivalent of DRAFT PR #42 now adapted to this repository (previously tailored to the MeteoSwsiss/neural-lam fork)
Outputting the inference results as GRIB format. Therefore, this needs the inference PR to be merged previously (loads of changes come from this).
This integrates the functionality of transforming the .npy array that is originally produced into a GRIB from a template. 

## Code changes:

- `ar_model`: add to the function `on_predict_epoch_end` a function generate_time_step to generate time steps markers for the grib files and a function that translates the npy output into a grib file. 
- other modifications to the code include adaptation to tsa, imports of new libraries for this functionality, and references to templates in `constants`

## Checklist

Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20157433/Factory).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README)

## Review

For the review process follow the guidelines at [Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20156488/Code+Review)