### PR TITLE
Change copyright notice to specify all contributors

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Joel Oskarsson, Tomas Landelius
+Copyright (c) 2023 Neural-LAM Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Motivation
As more people are now contributing to the code the copyright does not just belong to me and Tomas. To avoid having to update this with the name of every person contributing, I suggest to take some inspiration from e.g. https://github.com/pyg-team/pytorch_geometric/blob/master/LICENSE and https://github.com/numpy/numpy/blob/main/LICENSE.txt and use a general formulation "Neural-LAM contributors".

## Description of change
Change the copyright notice in the MIT license to "Neural-LAM Contributors". The year can stay 2023, as that is the first year the work (the code) was published. As me and Tomas are included under "Neural-LAM Contributors" this is strictly expanding the number of copyright holders.