### PR TITLE
Separate interior state and boundary forcing to only predict state

### DIFF
--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -41,6 +41,12 @@ class BaseGraphModel(ARModel):
         # Define sub-models
         # Feature embedders for grid
         self.mlp_blueprint_end = [args.hidden_dim] * (args.hidden_layers + 1)
+        # TODO Optional separate embedder for boundary nodes
+        assert self.grid_dim == self.boundary_dim, (
+            "Grid and boundary input dimension must be the same when using "
+            f"the same encoder, got grid_dim={self.grid_dim}, "
+            f"boundary_dim={self.boundary_dim}"
+        )
         self.grid_embedder = utils.make_mlp(
             [self.grid_dim] + self.mlp_blueprint_end
         )
@@ -98,12 +104,15 @@ class BaseGraphModel(ARModel):
         """
         raise NotImplementedError("process_step not implemented")
 
-    def predict_step(self, prev_state, prev_prev_state, forcing):
+    def predict_step(
+        self, prev_state, prev_prev_state, forcing, boundary_forcing
+    ):
         """
         Step state one step ahead using prediction model, X_{t-1}, X_t -> X_t+1
         prev_state: (B, num_grid_nodes, feature_dim), X_t
         prev_prev_state: (B, num_grid_nodes, feature_dim), X_{t-1}
         forcing: (B, num_grid_nodes, forcing_dim)
+        boundary_forcing: (B, num_boundary_nodes, boundary_forcing_dim)
         """
         batch_size = prev_state.shape[0]
 
@@ -117,12 +126,35 @@ class BaseGraphModel(ARModel):
             ),
             dim=-1,
         )
+        # Create full boundary node features of shape
+        # (B, num_boundary_nodes, boundary_dim)
+        boundary_features = torch.cat(
+            (
+                boundary_forcing,
+                self.expand_to_batch(self.boundary_static_features, batch_size),
+            ),
+            dim=-1,
+        )
 
         # Embed all features
         grid_emb = self.grid_embedder(grid_features)  # (B, num_grid_nodes, d_h)
+        boundary_emb = self.grid_embedder(boundary_features)
+        # (B, num_boundary_nodes, d_h)
         g2m_emb = self.g2m_embedder(self.g2m_features)  # (M_g2m, d_h)
         m2g_emb = self.m2g_embedder(self.m2g_features)  # (M_m2g, d_h)
         mesh_emb = self.embedd_mesh_nodes()
+
+        # Merge interior and boundary emb into input embedding
+        # TODO Can we enforce ordering in the graph creation process to make
+        # this just a concat instead?
+        input_emb = torch.zeros(
+            batch_size,
+            self.num_input_nodes,
+            grid_emb.shape[2],
+            device=grid_emb.device,
+        )
+        input_emb[:, self.interior_mask] = grid_emb
+        input_emb[:, self.boundary_mask] = boundary_emb
 
         # Map from grid to mesh
         mesh_emb_expanded = self.expand_to_batch(
@@ -130,9 +162,9 @@ class BaseGraphModel(ARModel):
         )  # (B, num_mesh_nodes, d_h)
         g2m_emb_expanded = self.expand_to_batch(g2m_emb, batch_size)
 
-        # This also splits representation into grid and mesh
+        # Encode to mesh
         mesh_rep = self.g2m_gnn(
-            grid_emb, mesh_emb_expanded, g2m_emb_expanded
+            input_emb, mesh_emb_expanded, g2m_emb_expanded
         )  # (B, num_mesh_nodes, d_h)
         # Also MLP with residual for grid representation
         grid_rep = grid_emb + self.encoding_grid_mlp(

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -76,9 +76,9 @@ class WeatherDataset(torch.utils.data.Dataset):
         self.random_subsample = split == "train"
 
         # Unnecessary to load all static data, but this is just dummy
-        border_mask_float = utils.load_static_data(dataset_name)["border_mask"]
-        self.border_mask = border_mask_float.to(torch.bool)[:, 0]
-        self.interior_mask = torch.logical_not(self.border_mask)
+        static_data = utils.load_static_data(dataset_name)
+        self.boundary_mask = static_data["boundary_mask"]
+        self.interior_mask = static_data["interior_mask"]
 
     def __len__(self):
         return len(self.sample_names)
@@ -158,9 +158,9 @@ class WeatherDataset(torch.utils.data.Dataset):
             sample = (sample - self.data_mean) / self.data_std
 
         # Sample should only contain interior
-        boundary_forcing_sample = sample[:, self.interior_mask]
+        boundary_forcing_sample = sample[:, self.boundary_mask]
         # (sample_len, N_boundary, d_features)
-        sample = sample[:, self.boundary_mask]
+        sample = sample[:, self.interior_mask]
 
         # Split up sample in init. states and target states
         init_states = sample[:2]  # (2, N_grid, d_features)
@@ -270,7 +270,7 @@ class WeatherDataset(torch.utils.data.Dataset):
         # (sample_len-2, N_grid, forcing_dim)
 
         # Forcing should only contain interior
-        boundary_forcing_forcing = forcing[:, self.interior_mask]
+        boundary_forcing_forcing = forcing[:, self.boundary_mask]
         # (sample_len-2, N_boundary, forcing_dim)
         forcing = forcing[:, self.interior_mask]
 


### PR DESCRIPTION
## Describe your changes

The goal of this PR is to establish a clear separation of the (predicted) state in the interior region and the boundary forcing coming from outside (and potentially overlapping with) the limited area. This PR performs these changes on the *modeling* side. That is from each batch is fetched from the dataset class and onward. Including how the tensors are propagated through the model, loss calculation, evaluation and plotting. This should be complemented with a separate PR for handling the data-loading side of things, where the boundary forcing could come from a separate dataset. That change should then build upon #66, once merged.

*Note:* In order to allow for working on this before the change has been done on the data loading side this currently includes changes in the MEPS npy dataset class that separates state and boundary already in there. This defines the interface between the dataset and model (currently missing https://github.com/mllam/neural-lam/issues/64 from #66, but that can easily be added later) and allows for working on these separately.

### After this change:

* The model will only predict outputs within the limited area considered
* Plots will only include points within the limited area (this could be expanded in a future PR to plot also boundary fields, but would require a mapping between state and boundary forcing dimensions to plot together)
* Graphs will have to be created using a boundary mask as in https://github.com/mllam/weather-model-graphs/pull/34 to make sure that the g2m-component only maps to the interior nodes.

## Issue Link

No issue. This relates to the overall rework of Reading Training Data, but would be good to put as separate point on roadmap.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
