### PR TITLE
Update test data to smaller and consistent domains in space and time

### DIFF
--- a/.github/workflows/ci-pdm-install-and-test-cpu.yml
+++ b/.github/workflows/ci-pdm-install-and-test-cpu.yml
@@ -24,8 +24,10 @@ jobs:
 
       - name: Install torch (CPU)
         run: |
-          pdm run python -m pip install torch  --index-url https://download.pytorch.org/whl/cpu
-          # check that the CPU version is installed
+          # torch version pinned to 2.5.1 for now so that we avoid the
+          # downgrade (and then GPU version install) when actually installing
+          # neural-lam
+          pdm run python -m pip install "torch==2.5.1" --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install package (including dev dependencies)
         run: |

--- a/.github/workflows/ci-pdm-install-and-test-cpu.yml
+++ b/.github/workflows/ci-pdm-install-and-test-cpu.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Load cache data
         uses: actions/cache/restore@v4
         with:
-          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.zip
-          key: ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.tar.gz
+          key: ${{ runner.os }}-meps-reduced-example-data-v0.3.0
           restore-keys: |
-            ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+            ${{ runner.os }}-meps-reduced-example-data-v0.3.0
 
       - name: Run tests
         run: |
@@ -51,5 +51,5 @@ jobs:
       - name: Save cache data
         uses: actions/cache/save@v4
         with:
-          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.zip
-          key: ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.tar.gz
+          key: ${{ runner.os }}-meps-reduced-example-data-v0.3.0

--- a/.github/workflows/ci-pdm-install-and-test-gpu.yml
+++ b/.github/workflows/ci-pdm-install-and-test-gpu.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Load cache data
         uses: actions/cache/restore@v4
         with:
-          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.zip
-          key: ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.tar.gz
+          key: ${{ runner.os }}-meps-reduced-example-data-v0.3.0
           restore-keys: |
-            ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+            ${{ runner.os }}-meps-reduced-example-data-v0.3.0
 
       - name: Run tests
         run: |
@@ -56,5 +56,5 @@ jobs:
       - name: Save cache data
         uses: actions/cache/save@v4
         with:
-          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.zip
-          key: ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.tar.gz
+          key: ${{ runner.os }}-meps-reduced-example-data-v0.3.0

--- a/.github/workflows/ci-pip-install-and-test-cpu.yml
+++ b/.github/workflows/ci-pip-install-and-test-cpu.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Load cache data
         uses: actions/cache/restore@v4
         with:
-          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.zip
-          key: ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.tar.gz
+          key: ${{ runner.os }}-meps-reduced-example-data-v0.3.0
           restore-keys: |
-            ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+            ${{ runner.os }}-meps-reduced-example-data-v0.3.0
 
       - name: Run tests
         run: |
@@ -41,5 +41,5 @@ jobs:
       - name: Save cache data
         uses: actions/cache/save@v4
         with:
-          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.zip
-          key: ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.tar.gz
+          key: ${{ runner.os }}-meps-reduced-example-data-v0.3.0

--- a/.github/workflows/ci-pip-install-and-test-cpu.yml
+++ b/.github/workflows/ci-pip-install-and-test-cpu.yml
@@ -15,7 +15,10 @@ jobs:
 
       - name: Install torch (CPU)
         run: |
-          python -m pip install torch  --index-url https://download.pytorch.org/whl/cpu
+          # torch version pinned to 2.5.1 for now so that we avoid the
+          # downgrade (and then GPU version install) when actually installing
+          # neural-lam
+          python -m pip install "torch==2.5.1"  --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install package (including dev dependencies)
         run: |

--- a/.github/workflows/ci-pip-install-and-test-gpu.yml
+++ b/.github/workflows/ci-pip-install-and-test-gpu.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Load cache data
         uses: actions/cache/restore@v4
         with:
-          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.zip
-          key: ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.tar.gz
+          key: ${{ runner.os }}-meps-reduced-example-data-v0.3.0
           restore-keys: |
-            ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+            ${{ runner.os }}-meps-reduced-example-data-v0.3.0
 
       - name: Run tests
         run: |
@@ -46,5 +46,5 @@ jobs:
       - name: Save cache data
         uses: actions/cache/save@v4
         with:
-          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.zip
-          key: ${{ runner.os }}-meps-reduced-example-data-v0.2.0
+          path: tests/datastore_examples/npyfilesmeps/meps_example_reduced.tar.gz
+          key: ${{ runner.os }}-meps-reduced-example-data-v0.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,10 +24,10 @@ DATASTORE_EXAMPLES_ROOT_PATH = Path("tests/datastore_examples")
 # Initializing variables for the s3 client
 S3_BUCKET_NAME = "mllam-testdata"
 S3_ENDPOINT_URL = "https://object-store.os-api.cci1.ecmwf.int"
-S3_FILE_PATH = "neural-lam/npy/meps_example_reduced.v0.2.0.zip"
+S3_FILE_PATH = "neural-lam/npy/meps_example_reduced.v0.3.0.tar.gz"
 S3_FULL_PATH = "/".join([S3_ENDPOINT_URL, S3_BUCKET_NAME, S3_FILE_PATH])
 TEST_DATA_KNOWN_HASH = (
-    "7ff2e07e04cfcd77631115f800c9d49188bb2a7c2a2777da3cea219f926d0c86"
+    "af16d87099944dda152cc988ce347173da68c56d3739c86ec53c8132981a93e6"
 )
 
 
@@ -39,9 +39,9 @@ def download_meps_example_reduced_dataset():
     pooch.retrieve(
         url=S3_FULL_PATH,
         known_hash=TEST_DATA_KNOWN_HASH,
-        processor=pooch.Unzip(extract_dir=""),
+        processor=pooch.Untar(extract_dir=""),
         path=root_path,
-        fname="meps_example_reduced.zip",
+        fname=S3_FILE_PATH.split("/")[-1],
     )
 
     config_path = dataset_path / "meps_example_reduced.datastore.yaml"

--- a/tests/datastore_examples/.gitignore
+++ b/tests/datastore_examples/.gitignore
@@ -1,2 +1,3 @@
 npyfilesmeps/*.zip
+npyfilesmeps/*.tar.gz
 npyfilesmeps/meps_example_reduced/

--- a/tests/datastore_examples/mdp/danra_100m_winds/danra.datastore.yaml
+++ b/tests/datastore_examples/mdp/danra_100m_winds/danra.datastore.yaml
@@ -8,8 +8,8 @@ output:
     forcing: [time, grid_index, forcing_feature]
   coord_ranges:
     time:
-      start: 1990-09-03T00:00
-      end: 1990-09-09T00:00
+      start: 2022-04-01T00:00
+      end: 2022-04-10T00:00
       step: PT3H
   chunking:
     time: 1
@@ -17,21 +17,21 @@ output:
     dim: time
     splits:
       train:
-        start: 1990-09-03T00:00
-        end: 1990-09-06T00:00
+        start: 2022-04-01T00:00
+        end: 2022-04-04T00:00
         compute_statistics:
           ops: [mean, std, diff_mean, diff_std]
           dims: [grid_index, time]
       val:
-        start: 1990-09-06T00:00
-        end: 1990-09-07T00:00
+        start: 2022-04-04T00:00
+        end: 2022-04-07T00:00
       test:
-        start: 1990-09-07T00:00
-        end: 1990-09-09T00:00
+        start: 2022-04-07T00:00
+        end: 2022-04-10T00:00
 
 inputs:
   danra_height_levels:
-    path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/height_levels.zarr
+    path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/danra/v2/height_levels.zarr
     dims: [time, x, y, altitude]
     variables:
       u:
@@ -56,7 +56,7 @@ inputs:
     target_output_variable: state
 
   danra_surface:
-    path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/single_levels.zarr
+    path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/danra/v2/single_levels.zarr
     dims: [time, x, y]
     variables:
       # use surface incoming shortwave radiation as forcing
@@ -74,7 +74,7 @@ inputs:
     target_output_variable: forcing
 
   danra_lsm:
-    path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/lsm.zarr
+    path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/danra/v2/single_levels.zarr
     dims: [x, y]
     variables:
       - lsm

--- a/tests/datastore_examples/mdp/danra_100m_winds/danra.datastore.yaml
+++ b/tests/datastore_examples/mdp/danra_100m_winds/danra.datastore.yaml
@@ -31,7 +31,7 @@ output:
 
 inputs:
   danra_height_levels:
-    path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/danra/v2/height_levels.zarr
+    path: https://object-store.os-api.cci1.ecmwf.int/mllam-testdata/danra_cropped/v0.2.0/height_levels.zarr
     dims: [time, x, y, altitude]
     variables:
       u:
@@ -56,7 +56,7 @@ inputs:
     target_output_variable: state
 
   danra_surface:
-    path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/danra/v2/single_levels.zarr
+    path: https://object-store.os-api.cci1.ecmwf.int/mllam-testdata/danra_cropped/v0.2.0/single_levels.zarr
     dims: [time, x, y]
     variables:
       # use surface incoming shortwave radiation as forcing
@@ -73,11 +73,12 @@ inputs:
         name_format: "{var_name}"
     target_output_variable: forcing
 
-  danra_lsm:
-    path: https://mllam-test-data.s3.eu-north-1.amazonaws.com/danra/v2/single_levels.zarr
+  danra_static:
+    path: https://object-store.os-api.cci1.ecmwf.int/mllam-testdata/danra_cropped/v0.2.0/single_levels.zarr
     dims: [x, y]
     variables:
       - lsm
+      - orography
     dim_mapping:
       grid_index:
         method: stack


### PR DESCRIPTION
## Describe your changes

I have completed creating new versions of our MEPS (npyfiles) and DANRA (zarr through mllam-data-prep) test data.

The key aims here were:
- Ensure the two test datasets overlap in time.
    - Both datasets now cover the first two weeks of April 2022 (i.e. 2022-04-01T00:00 to 2022-04-14T:00).
    - For the MEPS example the data is split into train, val and test to match the example given for the DANRA test dataset datastore in mllam-data-prep/neural-lam (train 2022-04-01 to 2024-04-04, val 2022-04-04 to 2022-04-07, test 2022-04-07 to 2022-04-10 respectively)
- Ensure the two test datasets overlap in their spatial domain
    - Both datasets have been cropped from their source data to cover a region roughly 100x100 grid points (although I made the domains have aspect ratios `!= 1` to ensure the test data would allow us to pick up on x/y coordinate ordering issues), centred on Copenhagen. Specifically the MEPS example has `64x100` grid points and the DANRA example `96x80`
- Make the test datasets smaller, by reducing the number of grid points and time-samples, so that test (hopefully) will execute more quickly. This is while retaining enough grid-points that the tests can meaningfully execute.

The new DANRA example dataset is built from v0.5.0 of DANRA converted to zarr that is stored on European Weather Cloud, e.g. https://object-store.os-api.cci1.ecmwf.int/danra/v0.5.0/height_levels.zarr
The new MEPS example dataset is built from 2022-04 training data sample dataset hosted at: https://nextcloud.liu.se/s/QdB9PQgjBX4Spa5/download/train_202204.zip

**Below are samples of the new cropped domain**:
*(these plots were created with `python -m neural_lam.datastore.plot_example ...`. The datasets have different resolution 2.5km vs 10km (I think?) in MEPS which is why the domain span is so different*

DANRA:
![danra_cropped](https://github.com/user-attachments/assets/f3696399-2455-4f16-b8a5-6e2f2947ceac)

MEPS:
![meps_cropped](https://github.com/user-attachments/assets/b658bf43-ac37-4277-9408-5968de952c22)

**Looking at change in timings (test execution time)**

With old test datasets:

`mdp` related only:
```bash
# cold boot (including download/preparation of zarr training dataset)
pdm run pytest --sw -s -k mdp  618.30s user 161.83s system 159% cpu 8:09.10 total
# warm boot (training dataset already exists, this will be usual when running tests repeatedly locally)
pdm run pytest --sw -s -k mdp  265.36s user 68.87s system 113% cpu 4:54.00 total
```

`npyfilemeps` related only:
```bash
# cold boot (including download of npyfiles training dataset)
pdm run pytest --sw -s -k npyfilesmeps  72.00s user 32.17s system 91% cpu 1:54.27 total
# warm boot (training dataset already exists, this will be usual when running tests repeatedly locally)
pdm run pytest --sw -s -k npyfilesmeps  28.51s user 13.32s system 101% cpu 41.115 total
```

With new test datasets:

`mdp` related only:
```bash
# cold boot (including download/preparation of zarr training dataset)
pdm run pytest --sw -s -k mdp  69.48s user 31.44s system 69% cpu 2:24.46 total
# warm boot (training dataset already exists, this will be usual when running tests repeatedly locally)
pdm run pytest --sw -s -k mdp  30.59s user 17.44s system 139% cpu 34.466 total
```

`npyfilemeps` related only:
```bash
# cold boot (including download of npyfiles training dataset)
pdm run pytest --sw -s -k npyfilesmeps  66.10s user 37.46s system 66% cpu 2:35.19 total
# warm boot (training dataset already exists, this will be usual when running tests repeatedly locally)
pdm run pytest --sw -s -k npyfilesmeps  29.19s user 17.48s system 112% cpu 41.603 total
```

So the main change here is a ~4x reduction for running the `mdp` related tests the first time and ~10x reduction on later executions. For the `npyfilesmeps` related tests the download time has increased ~ 25%, but the test execution after that is nearly unchanged (the MEPS example dataset is slightly larger now since it covers more timesteps than before, I changed the compression from `zip` to `.tar.gz` which took about 20% of the file size).

With the changes in this PR **the full execution of all tests takes ~ 4min30s on my laptop (cold boot) and ~1min30s once the test datasets have been downloaded once**. To reduce this execution down even further I think we should look into adding the possibility to use [cugraph](https://github.com/rapidsai/cugraph) in place of [networkx](https://github.com/networkx/networkx) for graph generation since the graph generation is quite slow (and apparently `cugraph` had the *exact same api*).

To keep this repo tidier and because this test data is used in both the mllam-data-prep and neural-lam packages I have put the notebooks that describe how the test data is prepared in their own repository: *link to follow once I've made sure that tests pass in CI/CD for this PR*

No change in dependencies required for this change.

I've tentatively called this a "new feature", but I think it would be more fitting to call this "maintenance" (like fixing issues with upstream packages, ci/cd infrastructure, etc) - maybe we need another "type of change" in the PR template?

## Issue Link

https://github.com/mllam/neural-lam/issues/75

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [x] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
