### PR TITLE
[WIP] Remove datastore arg from models since it is already in the config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ __MACOSX
 
 # exclude pdm.lock file so that both cpu and gpu versions of torch will be accepted by pdm
 pdm.lock
+experiments/test

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -13,7 +13,7 @@ import xarray as xr
 # Local
 from .. import metrics, vis
 from ..config import NeuralLAMConfig
-from ..datastore import BaseDatastore
+from ..datastore import BaseDatastore, init_datastore
 from ..loss_weighting import get_state_feature_weighting
 from ..weather_dataset import WeatherDataset
 
@@ -36,6 +36,9 @@ class ARModel(pl.LightningModule):
         super().__init__()
         self.save_hyperparameters(ignore=["datastore"])
         self.args = args
+        datastore = init_datastore(
+            config.datastore.kind, config.datastore.config_path
+        )
         self._datastore = datastore
         num_state_vars = datastore.get_num_data_vars(category="state")
         num_forcing_vars = datastore.get_num_data_vars(category="forcing")

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -13,7 +13,7 @@ import xarray as xr
 # Local
 from .. import metrics, vis
 from ..config import NeuralLAMConfig
-from ..datastore import BaseDatastore, init_datastore
+from ..datastore import init_datastore
 from ..loss_weighting import get_state_feature_weighting
 from ..weather_dataset import WeatherDataset
 

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -41,7 +41,7 @@ class ARModel(pl.LightningModule):
         self._datastore = datastore
         num_state_vars = datastore.get_num_data_vars(category="state")
         num_forcing_vars = datastore.get_num_data_vars(category="forcing")
-        # Load static features standardized
+
         da_static_features = datastore.get_dataarray(
             category="static", split=None, standardize=True
         )

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -31,7 +31,6 @@ class ARModel(pl.LightningModule):
         self,
         args,
         config: NeuralLAMConfig,
-        datastore: BaseDatastore,
     ):
         super().__init__()
         self.save_hyperparameters(ignore=["datastore"])

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -15,8 +15,8 @@ class BaseGraphModel(ARModel):
     the encode-process-decode idea.
     """
 
-    def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
-        super().__init__(args, config=config, datastore=datastore)
+    def __init__(self, args, config: NeuralLAMConfig):
+        super().__init__(args, config=config)
 
         # Load graph with static features
         # NOTE: (IMPORTANT!) mesh nodes MUST have the first

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -4,7 +4,6 @@ import torch
 # Local
 from .. import utils
 from ..config import NeuralLAMConfig
-from ..datastore import BaseDatastore
 from ..interaction_net import InteractionNet
 from .ar_model import ARModel
 

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -25,7 +25,6 @@ class BaseGraphModel(ARModel):
             graph_dir_path=graph_dir_path
         )
         for name, attr_value in graph_ldict.items():
-            # Make BufferLists module members and register tensors as buffers
             if isinstance(attr_value, torch.Tensor):
                 self.register_buffer(name, attr_value, persistent=False)
             else:

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -21,7 +21,7 @@ class BaseGraphModel(ARModel):
         # Load graph with static features
         # NOTE: (IMPORTANT!) mesh nodes MUST have the first
         # num_mesh_nodes indices,
-        graph_dir_path = datastore.root_path / "graph" / args.graph
+        graph_dir_path = self._datastore.root_path / "graph" / args.graph
         self.hierarchical, graph_ldict = utils.load_graph(
             graph_dir_path=graph_dir_path
         )

--- a/neural_lam/models/base_hi_graph_model.py
+++ b/neural_lam/models/base_hi_graph_model.py
@@ -14,8 +14,8 @@ class BaseHiGraphModel(BaseGraphModel):
     Base class for hierarchical graph models.
     """
 
-    def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
-        super().__init__(args, config=config, datastore=datastore)
+    def __init__(self, args, config: NeuralLAMConfig):
+        super().__init__(args, config=config)
 
         # Track number of nodes, edges on each level
         # Flatten lists for efficient embedding

--- a/neural_lam/models/base_hi_graph_model.py
+++ b/neural_lam/models/base_hi_graph_model.py
@@ -4,7 +4,6 @@ from torch import nn
 # Local
 from .. import utils
 from ..config import NeuralLAMConfig
-from ..datastore import BaseDatastore
 from ..interaction_net import InteractionNet
 from .base_graph_model import BaseGraphModel
 

--- a/neural_lam/models/graph_lam.py
+++ b/neural_lam/models/graph_lam.py
@@ -17,8 +17,8 @@ class GraphLAM(BaseGraphModel):
     Oskarsson et al. (2023).
     """
 
-    def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
-        super().__init__(args, config=config, datastore=datastore)
+    def __init__(self, args, config: NeuralLAMConfig):
+        super().__init__(args, config=config)
 
         assert (
             not self.hierarchical

--- a/neural_lam/models/graph_lam.py
+++ b/neural_lam/models/graph_lam.py
@@ -4,7 +4,6 @@ import torch_geometric as pyg
 # Local
 from .. import utils
 from ..config import NeuralLAMConfig
-from ..datastore import BaseDatastore
 from ..interaction_net import InteractionNet
 from .base_graph_model import BaseGraphModel
 

--- a/neural_lam/models/hi_lam.py
+++ b/neural_lam/models/hi_lam.py
@@ -3,7 +3,6 @@ from torch import nn
 
 # Local
 from ..config import NeuralLAMConfig
-from ..datastore import BaseDatastore
 from ..interaction_net import InteractionNet
 from .base_hi_graph_model import BaseHiGraphModel
 

--- a/neural_lam/models/hi_lam.py
+++ b/neural_lam/models/hi_lam.py
@@ -15,8 +15,8 @@ class HiLAM(BaseHiGraphModel):
     The Hi-LAM model from Oskarsson et al. (2023)
     """
 
-    def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
-        super().__init__(args, config=config, datastore=datastore)
+    def __init__(self, args, config: NeuralLAMConfig):
+        super().__init__(args, config=config)
 
         # Make down GNNs, both for down edges and same level
         self.mesh_down_gnns = nn.ModuleList(

--- a/neural_lam/models/hi_lam_parallel.py
+++ b/neural_lam/models/hi_lam_parallel.py
@@ -18,8 +18,8 @@ class HiLAMParallel(BaseHiGraphModel):
     of Hi-LAM.
     """
 
-    def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
-        super().__init__(args, config=config, datastore=datastore)
+    def __init__(self, args, config: NeuralLAMConfig):
+        super().__init__(args, config=config)
 
         # Processor GNNs
         # Create the complete edge_index combining all edges for processing

--- a/neural_lam/models/hi_lam_parallel.py
+++ b/neural_lam/models/hi_lam_parallel.py
@@ -4,7 +4,6 @@ import torch_geometric as pyg
 
 # Local
 from ..config import NeuralLAMConfig
-from ..datastore import BaseDatastore
 from ..interaction_net import InteractionNet
 from .base_hi_graph_model import BaseHiGraphModel
 

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -284,7 +284,7 @@ def main(input_args=None):
 
     # Load model parameters Use new args for model
     ModelClass = MODELS[args.model]
-    model = ModelClass(args, config=config, datastore=datastore)
+    model = ModelClass(args, config=config)
 
     if args.eval:
         prefix = f"eval-{args.eval}-"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # Standard library
 import os
+import tempfile
 from pathlib import Path
 
 # Third-party
@@ -91,7 +92,7 @@ DATASTORES_EXAMPLES = dict(
         / "danra.datastore.yaml"
     ),
     npyfilesmeps=download_meps_example_reduced_dataset(),
-    dummydata=None,
+    dummydata=tempfile.TemporaryDirectory().name,
 )
 
 DATASTORES[DummyDatastore.SHORT_NAME] = DummyDatastore

--- a/tests/dummy_datastore.py
+++ b/tests/dummy_datastore.py
@@ -1,5 +1,6 @@
 # Standard library
 import datetime
+import os
 import tempfile
 from functools import cached_property
 from pathlib import Path
@@ -52,9 +53,13 @@ class DummyDatastore(BaseRegularGridDatastore):
         n_timesteps : int
             The number of timesteps in the dataset.
         """
-        assert (
-            config_path is None
-        ), "No config file is needed for the dummy datastore"
+        if config_path:
+            self._root_path = Path(os.path.dirname(config_path))
+        else:
+            self._tempdir = tempfile.TemporaryDirectory()
+            self._root_path = Path(self._tempdir.name)
+
+        self._num_grid_points = n_grid_points
 
         # Ensure n_grid_points is a perfect square
         n_points_1d = int(np.sqrt(n_grid_points))
@@ -156,11 +161,6 @@ class DummyDatastore(BaseRegularGridDatastore):
 
         # Stack the spatial dimensions into grid_index
         self.ds = self.ds.stack(grid_index=self.CARTESIAN_COORDS)
-
-        # Create temporary directory for storing derived files
-        self._tempdir = tempfile.TemporaryDirectory()
-        self._root_path = Path(self._tempdir.name)
-        self._num_grid_points = n_grid_points
 
     @property
     def root_path(self) -> Path:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -213,7 +213,10 @@ def test_single_batch(datastore_name, split):
 
     dataset = WeatherDataset(datastore=datastore, split=split, ar_steps=2)
 
-    model = GraphLAM(args=args, datastore=datastore, config=config)  # noqa
+    model = GraphLAM(
+        args=args,
+        config=config,
+    )  # noqa
 
     model_device = model.to(device_name)
     data_loader = DataLoader(dataset, batch_size=2)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -14,7 +14,7 @@ from neural_lam.datastore import DATASTORES
 from neural_lam.datastore.base import BaseRegularGridDatastore
 from neural_lam.models.graph_lam import GraphLAM
 from neural_lam.weather_dataset import WeatherDataset
-from tests.conftest import init_datastore_example
+from tests.conftest import DATASTORES_EXAMPLES, init_datastore_example
 from tests.dummy_datastore import DummyDatastore
 
 
@@ -165,6 +165,7 @@ def test_single_batch(datastore_name, split):
 
     """
     datastore = init_datastore_example(datastore_name)
+    datastore_path = DATASTORES_EXAMPLES[datastore_name]
 
     device_name = (
         torch.device("cuda") if torch.cuda.is_available() else "cpu"
@@ -206,7 +207,7 @@ def test_single_batch(datastore_name, split):
 
     config = nlconfig.NeuralLAMConfig(
         datastore=nlconfig.DatastoreSelection(
-            kind=datastore.SHORT_NAME, config_path=datastore.root_path
+            kind=datastore.SHORT_NAME, config_path=datastore_path
         )
     )
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -97,7 +97,6 @@ def test_training(datastore_name):
 
     model = GraphLAM(  # noqa
         args=model_args,
-        datastore=datastore,
         config=config,
     )
     wandb.init()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -14,12 +14,13 @@ from neural_lam.datastore import DATASTORES
 from neural_lam.datastore.base import BaseRegularGridDatastore
 from neural_lam.models.graph_lam import GraphLAM
 from neural_lam.weather_dataset import WeatherDataModule
-from tests.conftest import init_datastore_example
+from tests.conftest import DATASTORES_EXAMPLES, init_datastore_example
 
 
 @pytest.mark.parametrize("datastore_name", DATASTORES.keys())
 def test_training(datastore_name):
     datastore = init_datastore_example(datastore_name)
+    datastore_path = DATASTORES_EXAMPLES[datastore_name]
 
     if not isinstance(datastore, BaseRegularGridDatastore):
         pytest.skip(
@@ -90,7 +91,7 @@ def test_training(datastore_name):
 
     config = nlconfig.NeuralLAMConfig(
         datastore=nlconfig.DatastoreSelection(
-            kind=datastore.SHORT_NAME, config_path=datastore.root_path
+            kind=datastore.SHORT_NAME, config_path=datastore_path
         )
     )
 


### PR DESCRIPTION
### Context
So this is a WIP MR, and I'm not sure we are interested in this design at all, I just made the MR to save the work for later if we want to pick it up. 

I've been looking randomly through the codebase to see how everything is working together - I noticed that instantiating the model is quite hard—see [this example](https://github.com/mllam/neural-lam/blob/f342487600a7da77514ee489fe59fd42952eae49/tests/test_training.py#L21). This complexity makes it difficult to test and reuse the model outside of the main training script.

### Issue
There is some redundancy in how the model datastores are passed to the model during instantiation. Specifically, the model:
Accepts a NeuralLAMConfig, which includes both datastore_path and datastore_type.
Also takes an already instantiated datastore object as an argument.
This means the model effectively gets the same information from two different sources, leading to unnecessary complexity.

### Proposed Change
To streamline instantiation, I removed the datastore from the model's arguments and instead let the model instantiate it internally based on the provided config. This should reduce redundancy in argument passing and make it easier to instantiate the model for usage in different scripts.

### Thoughts 
I think that the model should not have a datastore as a member since it introduces a tight coupling between model and data and is against the core modular philosophy of neurallam

No change of dependencies

## Issue Link

< Link to the relevant issue or task. > (e.g. `closes #00` or `solves #00`)

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
