### PR TITLE
Dev/feat/ignore ssl cert when using mlflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased](https://github.com/mllam/neural-lam/compare/v0.3.0...HEAD)
+## [DMI Gefion development changes](https://github.com/mllam/neural-lam/compare/main...dmidk:neural-lam:dev/gefion)
+
+*Below is a list of changes since the DMI Gefion development fork was branched from the [main neural-lam repo](https://github.com/mllam/neural-lam)*
+
+### Added
+
+- Add option to provide user-defined run name via CLI. [\#1](https://github.com/dmidk/neural-lam/pull/1)
+
+- Log evaluation images to `save_dir` and create folder if needed. [\#2](https://github.com/dmidk/neural-lam/pull/2)
+
+
+*Below follows changelog from the main neural-lam repository:*
+
+## [unreleased](https://github.com/mllam/neural-lam/compare/v0.3.0...ada9c1644beb56de832127cba46971b1be1bdd98)
 
 ### Added
 

--- a/neural_lam/custom_loggers.py
+++ b/neural_lam/custom_loggers.py
@@ -48,6 +48,9 @@ class CustomMLFlowLogger(pl.loggers.MLFlowLogger):
         step: Union[int, None]
             Step to log the image under. If None, logs under the key directly
         """
+        # Standard library
+        import os
+
         # Third-party
         from botocore.exceptions import NoCredentialsError
         from PIL import Image
@@ -57,12 +60,14 @@ class CustomMLFlowLogger(pl.loggers.MLFlowLogger):
 
         # Need to save the image to a temporary file, then log that file
         # mlflow.log_image, should do this automatically, but is buggy
-        temporary_image = f"{key}.png"
-        images[0].savefig(temporary_image)
+        if not os.path.exists(self.save_dir):
+            os.makedirs(self.save_dir)
+        path = f"{self.save_dir}/{key}.png"
+        images[0].savefig(path)
 
-        img = Image.open(temporary_image)
+        img = Image.open(path)
         try:
-            mlflow.log_image(img, f"{key}.png")
+            mlflow.log_image(img, path)
         except NoCredentialsError:
             logger.error("Error logging image\nSet AWS credentials")
             sys.exit(1)

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -196,6 +196,12 @@ def main(input_args=None):
         help="Logger project name, for eg. Wandb (default: neural_lam)",
     )
     parser.add_argument(
+        "--logger_run_name",
+        type=str,
+        default=None,
+        help="Logger run name, for e.g. MLFlow (with default value `None` neural-lam default format string is used)",
+    )
+    parser.add_argument(
         "--val_steps_to_log",
         nargs="+",
         type=int,
@@ -290,10 +296,14 @@ def main(input_args=None):
         prefix = f"eval-{args.eval}-"
     else:
         prefix = "train-"
-    run_name = (
-        f"{prefix}{args.model}-{args.processor_layers}x{args.hidden_dim}-"
-        f"{time.strftime('%m_%d_%H')}-{random_run_id:04d}"
-    )
+
+    if args.logger_run_name:
+        run_name = args.logger_run_name
+    else:
+        run_name = (
+            f"{prefix}{args.model}-{args.processor_layers}x{args.hidden_dim}-"
+            f"{time.strftime('%m_%d_%H')}-{random_run_id:04d}"
+        )
 
     training_logger = utils.setup_training_logger(
         datastore=datastore, args=args, run_name=run_name

--- a/neural_lam/utils.py
+++ b/neural_lam/utils.py
@@ -6,6 +6,7 @@ import warnings
 # Third-party
 import pytorch_lightning as pl
 import torch
+import urllib3
 from pytorch_lightning.loggers import MLFlowLogger, WandbLogger
 from pytorch_lightning.utilities import rank_zero_only
 from torch import nn
@@ -297,6 +298,11 @@ def setup_training_logger(datastore, args, run_name):
             raise ValueError(
                 "MLFlow logger requires setting MLFLOW_TRACKING_URI in env."
             )
+
+        # suppress warnings about insecure requests so that we avoid warnings in
+        # the logs when tracking on the MLflow tracking server
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
         logger = CustomMLFlowLogger(
             experiment_name=args.logger_project,
             tracking_uri=url,


### PR DESCRIPTION
## Describe your changes

Currently our SLURM logs are full of the following kind of warnings during training (which makes using the logs quite hard):

```
 0:   warnings.warn(
 0: ^MEpoch 0:   1% 6/731 [00:14<29:12,  2.42s/it, v_num=d4e6, train_loss_step=nan.0]
 0: ^MEpoch 0:   1% 6/731 [00:14<29:12,  2.42s/it, v_num=d4e6, train_loss_step=nan.0]
 0: /dcai/users/denlef/packages_dvc/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'mlflow.dmi.dcs.dcai.dk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
 0:   warnings.warn(
 0: ^MEpoch 0:   1% 7/731 [00:15<27:19,  2.27s/it, v_num=d4e6, train_loss_step=nan.0]
 0: ^MEpoch 0:   1% 7/731 [00:15<27:20,  2.27s/it, v_num=d4e6, train_loss_step=nan.0]
 0: /dcai/users/denlef/packages_dvc/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'mlflow.dmi.dcs.dcai.dk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
 0:   warnings.warn(
 0: ^MEpoch 0:   1% 8/731 [00:17<25:54,  2.15s/it, v_num=d4e6, train_loss_step=nan.0]^MEpoch 0:   1% 8/731 [00:17<25:54,  2.15s/it, v_num=d4e6, train_loss_step=nan.0]
 0: /dcai/users/denlef/packages_dvc/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'mlflow.dmi.dcs.dcai.dk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
 0:   warnings.warn(
 0: /dcai/users/denlef/packages_dvc/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'mlflow.dmi.dcs.dcai.dk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
 0:   warnings.warn(
 0: /dcai/users/denlef/packages_dvc/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'mlflow.dmi.dcs.dcai.dk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
```

This PR adds a`urllib3` line to ignore warnings about unverified HTTPs connections when using the mlflow logger

no change of deps for this work

## Issue Link

n/a

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
