### PR TITLE
fix: correct attribute name from time_step_int_unit to time_step_unit

### DIFF
--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -709,7 +709,7 @@ class ARModel(pl.LightningModule):
                     error=loss_map,
                     datastore=self._datastore,
                     title=f"Test loss, t={t_i} "
-                    f"({(self.time_step_int * t_i)} {self.time_step_int_unit})",
+                    f"({(self.time_step_int * t_i)} {self.time_step_unit})",
                 )
                 for t_i, loss_map in zip(
                     self.args.val_steps_to_log, mean_spatial_loss


### PR DESCRIPTION
## Summary
Fixes an `AttributeError` that crashes evaluation when `on_test_epoch_end` tries to plot spatial loss maps.

## Problem
Line 712 in `ar_model.py` references `self.time_step_int_unit`, but the attribute is actually named `self.time_step_unit` (set on lines 159-161).

```python
# Line 712 — WRONG
f"({(self.time_step_int * t_i)} {self.time_step_int_unit})"

# Should be
f"({(self.time_step_int * t_i)} {self.time_step_unit})"
```

## Changes
- Fixed attribute name typo: `time_step_int_unit` → `time_step_unit`

## Testing
- ✅ Python syntax check passed (`py_compile`)

## Impact
This fix prevents the crash that occurs every time evaluation tries to plot spatial loss maps.

Closes #203