### PR TITLE
test: verify datastore is omitted from checkpoint hparams (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add unit tests for `inverse_softplus` covering roundtrip identity (parametrized over `beta`), near-zero clamping, and above-threshold linear passthrough [\#419](https://github.com/mllam/neural-lam/pull/419) @Riteesh-NITT
 
+- Add regression test that `datastore` and `forecaster` stay excluded from the saved Lightning hyperparameters (in-memory and on-disk after a checkpoint round-trip), so `load_from_checkpoint` continues to require them to be passed in explicitly ([#148](https://github.com/mllam/neural-lam/issues/148)) [\#232](https://github.com/mllam/neural-lam/pull/232) @Jayant-kernel
+
 - Add comprehensive type hints to `neural_lam/metrics.py` [\#447](https://github.com/mllam/neural-lam/pull/447) @sidhantpande
 
 - Add type hints to methods in `neural_lam/custom_loggers.py` [\#455](https://github.com/mllam/neural-lam/pull/455) @sidhantpande

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,85 @@
+# Standard library
+from pathlib import Path
+
+# Third-party
+import pytorch_lightning as pl
+import torch
+
+# First-party
+from neural_lam import config as nlconfig
+from neural_lam.create_graph import create_graph_from_datastore
+from neural_lam.models import ARForecaster, ForecasterModule, GraphLAM
+from tests.dummy_datastore import DummyDatastore
+
+
+def test_saved_checkpoint_excludes_datastore_and_forecaster(tmp_path):
+    """
+    Regression check for issue #148: heavy non-pickle-safe objects
+    (`datastore`, `forecaster`) must be excluded from the saved Lightning
+    hyperparameters so that checkpoints stay small and portable, and so
+    that `load_from_checkpoint` requires them to be passed in explicitly.
+    """
+    datastore = DummyDatastore()
+
+    # Build the minimum graph the GraphLAM predictor needs.
+    graph_dir_path = Path(datastore.root_path) / "graph" / "1level"
+    if not graph_dir_path.exists():
+        create_graph_from_datastore(
+            datastore=datastore,
+            output_root_path=str(graph_dir_path),
+            n_max_levels=1,
+        )
+
+    config = nlconfig.NeuralLAMConfig(
+        datastore=nlconfig.DatastoreSelection(
+            kind=datastore.SHORT_NAME,
+            config_path=datastore.root_path,
+        ),
+    )
+
+    predictor = GraphLAM(
+        datastore=datastore,
+        graph_name="1level",
+        hidden_dim=4,
+        hidden_layers=1,
+        processor_layers=1,
+        mesh_aggr="sum",
+        num_past_forcing_steps=0,
+        num_future_forcing_steps=0,
+        output_std=False,
+        output_clamping_lower=config.training.output_clamping.lower,
+        output_clamping_upper=config.training.output_clamping.upper,
+    )
+    forecaster = ARForecaster(predictor, datastore)
+    model = ForecasterModule(
+        forecaster=forecaster,
+        config=config,
+        datastore=datastore,
+        loss="mse",
+        lr=1.0e-3,
+        n_example_pred=1,
+        val_steps_to_log=[1],
+    )
+
+    # Lightning's in-memory hparams must already drop these.
+    assert "datastore" not in model.hparams
+    assert "forecaster" not in model.hparams
+
+    # And the on-disk checkpoint round-trip must agree.
+    trainer = pl.Trainer(
+        default_root_dir=tmp_path,
+        accelerator="cpu",
+        max_epochs=0,
+        logger=False,
+        enable_checkpointing=False,
+    )
+    trainer.strategy.connect(model)
+
+    ckpt_path = tmp_path / "test.ckpt"
+    trainer.save_checkpoint(ckpt_path, weights_only=False)
+
+    # In-process checkpoint, trusted source.
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    assert "hyper_parameters" in ckpt
+    assert "datastore" not in ckpt["hyper_parameters"]
+    assert "forecaster" not in ckpt["hyper_parameters"]


### PR DESCRIPTION
## Describe your changes

This PR adds a minimal regression test to verify that the [datastore](cci:1://file:///c:/Users/jayan/Desktop/Mlaam%20gsoc/neural-lam/tests/conftest.py:100:0-106:20) object is correctly excluded from the pickled PyTorch Lightning checkpoint hyperparameters. 

The `save_hyperparameters(ignore=["datastore"])` call was already previously implemented inside [ARModel](cci:2://file:///c:/Users/jayan/Desktop/Mlaam%20gsoc/neural-lam/neural_lam/models/ar_model.py:23:0-770:63) and successfully propagates to all model subclasses via `super().__init__()`. This test simply locks in that behavior by saving a checkpoint to disk and asserting the dictionary keys, ensuring no future refactors accidentally bypass it.

- Instantiates a minimal dummy graph and [GraphLAM](cci:2://file:///c:/Users/jayan/Desktop/Mlaam%20gsoc/neural-lam/neural_lam/models/graph_lam.py:11:0-90:23) model.
- Mimics Lightning's standard `trainer.save_checkpoint`.
- Asserts that `"datastore"` is absent from the saved `checkpoint["hyper_parameters"]` dictionary.

## Issue Link

Closes #148

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the README to cover introduced code changes (N/A)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form.
- [x] I have requested a reviewer and an assignee

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [x] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [x] PR is up to date with the base branch
- [x] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)

