### PR TITLE
Refactor ARModel: Extract evaluation and plotting into stateless function

### DIFF
--- a/neural_lam/evaluation.py
+++ b/neural_lam/evaluation.py
@@ -1,0 +1,324 @@
+# Standard library
+import os
+import warnings
+from typing import Any, Dict, List
+
+# Third-party
+import matplotlib.pyplot as plt
+import numpy as np
+import pytorch_lightning as pl
+import torch
+import xarray as xr
+
+# Local
+from . import vis
+from .utils import get_integer_time
+from .weather_dataset import WeatherDataset
+
+
+def create_dataarray_from_tensor(
+    tensor: torch.Tensor,
+    time: np.ndarray,
+    split: str,
+    category: str,
+    datastore: Any,
+) -> xr.DataArray:
+    """
+    Create an `xr.DataArray` from a tensor, with the correct dimensions and
+    coordinates to match the datastore used by the model. This function in
+    in effect is the inverse of what is returned by
+    `WeatherDataset.__getitem__`.
+
+    Parameters
+    ----------
+    tensor : torch.Tensor
+        The tensor to convert to a `xr.DataArray` with dimensions [time,
+        grid_index, feature]. The tensor will be copied to the CPU if it is
+        not already there.
+    time : np.ndarray
+        The time index or indices for the data.
+    split : str
+        The split of the data, either 'train', 'val', or 'test'
+    category : str
+        The category of the data, either 'state' or 'forcing'
+    datastore : BaseDatastore
+        The datastore object used.
+    """
+    weather_dataset = WeatherDataset(datastore=datastore, split=split)
+    da = weather_dataset.create_dataarray_from_tensor(
+        tensor=tensor, time=time, category=category
+    )
+    return da
+
+
+def plot_examples(
+    datastore: Any,
+    prediction: torch.Tensor,
+    target: torch.Tensor,
+    time: torch.Tensor,
+    n_examples: int,
+    split: str,
+    plotted_examples: int,
+    state_std: torch.Tensor,
+    state_mean: torch.Tensor,
+    save_dir: str,
+    logger: Any,
+) -> int:
+    """
+    Plot the first n_examples forecasts from batch
+
+    datastore: datastore object
+    prediction: (B, pred_steps, num_grid_nodes, d_f), existing prediction.
+    target: (B, pred_steps, num_grid_nodes, d_f), target.
+    time: tensor with times
+    n_examples: number of forecasts to plot
+    split: split info
+    plotted_examples: already plotted example count
+    state_std: standard deviation buffer for state
+    state_mean: mean buffer for state
+    save_dir: directory to save `.pt` example slices
+    logger: PyTorch Lightning logger
+    """
+    # Rescale to original data scale
+    prediction_rescaled = prediction * state_std + state_mean
+    target_rescaled = target * state_std + state_mean
+
+    time_step_int, time_step_unit = get_integer_time(datastore.step_length)
+
+    # Iterate over the examples
+    for pred_slice, target_slice, time_slice in zip(
+        prediction_rescaled[:n_examples],
+        target_rescaled[:n_examples],
+        time[:n_examples],
+    ):
+        # Each slice is (pred_steps, num_grid_nodes, d_f)
+        plotted_examples += 1  # Increment already here
+
+        time_slice_np = np.array(time_slice.cpu(), dtype="datetime64[ns]")
+
+        da_prediction = create_dataarray_from_tensor(
+            tensor=pred_slice,
+            time=time_slice_np,
+            split=split,
+            category="state",
+            datastore=datastore,
+        ).unstack("grid_index")
+        da_target = create_dataarray_from_tensor(
+            tensor=target_slice,
+            time=time_slice_np,
+            split=split,
+            category="state",
+            datastore=datastore,
+        ).unstack("grid_index")
+
+        var_vmin = (
+            torch.minimum(
+                pred_slice.flatten(0, 1).min(dim=0)[0],
+                target_slice.flatten(0, 1).min(dim=0)[0],
+            )
+            .cpu()
+            .numpy()
+        )  # (d_f,)
+        var_vmax = (
+            torch.maximum(
+                pred_slice.flatten(0, 1).max(dim=0)[0],
+                target_slice.flatten(0, 1).max(dim=0)[0],
+            )
+            .cpu()
+            .numpy()
+        )  # (d_f,)
+        var_vranges = list(zip(var_vmin, var_vmax))
+
+        # Iterate over prediction horizon time steps
+        for t_i, _ in enumerate(zip(pred_slice, target_slice), start=1):
+            # Create one figure per variable at this time step
+            var_figs = [
+                vis.plot_prediction(
+                    datastore=datastore,
+                    title=f"{var_name} ({var_unit}), "
+                    f"t={t_i} ({(time_step_int * t_i)}"
+                    f"{time_step_unit})",
+                    vrange=var_vrange,
+                    da_prediction=da_prediction.isel(
+                        state_feature=var_i, time=t_i - 1
+                    ).squeeze(),
+                    da_target=da_target.isel(
+                        state_feature=var_i, time=t_i - 1
+                    ).squeeze(),
+                )
+                for var_i, (var_name, var_unit, var_vrange) in enumerate(
+                    zip(
+                        datastore.get_vars_names("state"),
+                        datastore.get_vars_units("state"),
+                        var_vranges,
+                    )
+                )
+            ]
+
+            example_i = plotted_examples
+
+            for var_name, fig in zip(
+                datastore.get_vars_names("state"), var_figs
+            ):
+
+                # We need treat logging images differently for different
+                # loggers. WANDB can log multiple images to the same key,
+                # while other loggers, as MLFlow, need unique keys for
+                # each image.
+                if isinstance(logger, pl.loggers.WandbLogger):
+                    key = f"{var_name}_example_{example_i}"
+                else:
+                    key = f"{var_name}_example"
+
+                if hasattr(logger, "log_image"):
+                    logger.log_image(key=key, images=[fig], step=t_i)
+                else:
+                    warnings.warn(
+                        f"{logger} does not support image logging."
+                    )
+
+            plt.close(
+                "all"
+            )  # Close all figs for this time step, saves memory
+
+        # Save pred and target as .pt files
+        torch.save(
+            pred_slice.cpu(),
+            os.path.join(
+                save_dir,
+                f"example_pred_{plotted_examples}.pt",
+            ),
+        )
+        torch.save(
+            target_slice.cpu(),
+            os.path.join(
+                save_dir,
+                f"example_target_{plotted_examples}.pt",
+            ),
+        )
+
+    return plotted_examples
+
+
+def create_metric_log_dict(
+    metric_tensor: torch.Tensor,
+    prefix: str,
+    metric_name: str,
+    datastore: Any,
+    save_dir: str,
+    metrics_watch: List[str],
+    var_leads_metrics_watch: Dict[int, List[int]],
+) -> Dict[str, Any]:
+    """
+    Put together a dict with everything to log for one metric. Also saves
+    plots as pdf and csv if using test prefix.
+
+    metric_tensor: (pred_steps, d_f), metric values per time and variable
+    prefix: string, prefix to use for logging metric_name: string, name of
+    the metric
+    datastore: Datastore object for extracting variables
+    save_dir: Directory where the csv and pdf are saved for test split
+    metrics_watch: The metrics being monitored explicitly
+    var_leads_metrics_watch: Lead-variables that are being checked
+
+    Return: log_dict: dict with everything to log for given metric
+    """
+    log_dict = {}
+    metric_fig = vis.plot_error_map(
+        errors=metric_tensor,
+        datastore=datastore,
+    )
+    full_log_name = f"{prefix}_{metric_name}"
+    log_dict[full_log_name] = metric_fig
+
+    if prefix == "test":
+        # Save pdf
+        metric_fig.savefig(
+            os.path.join(save_dir, f"{full_log_name}.pdf")
+        )
+        # Save errors also as csv
+        np.savetxt(
+            os.path.join(save_dir, f"{full_log_name}.csv"),
+            metric_tensor.cpu().numpy(),
+            delimiter=",",
+        )
+
+    # Check if metrics are watched, log exact values for specific vars
+    var_names = datastore.get_vars_names(category="state")
+    if full_log_name in metrics_watch:
+        for var_i, timesteps in var_leads_metrics_watch.items():
+            var_name = var_names[var_i]
+            for step in timesteps:
+                key = f"{full_log_name}_{var_name}_step_{step}"
+                log_dict[key] = metric_tensor[step - 1, var_i]
+
+    return log_dict
+
+
+def evaluate_metrics(
+    metrics_dict: Dict[str, List[torch.Tensor]],
+    prefix: str,
+    state_std: torch.Tensor,
+    datastore: Any,
+    save_dir: str,
+    metrics_watch: List[str],
+    var_leads_metrics_watch: Dict[int, List[int]],
+    all_gather_cat_fn: Any,
+    is_global_zero: bool,
+) -> Dict[str, Any]:
+    """
+    Aggregate and create error map plots for all metrics in metrics_dict
+
+    metrics_dict: dictionary with metric_names and list of tensors
+        with step-evals.
+    prefix: string, prefix to use for logging
+    state_std: standard deviations for state variables
+    datastore: Datastore object for setting vars
+    save_dir: Path to directory where test plots are output
+    metrics_watch: Monitored metric lists
+    var_leads_metrics_watch: Variable lists checked
+    all_gather_cat_fn: Distributing function to gather tensors across ranks
+    is_global_zero: Checked for gathering rank root
+    """
+    log_dict = {}
+    for metric_name, metric_val_list in metrics_dict.items():
+        metric_tensor = all_gather_cat_fn(
+            torch.cat(metric_val_list, dim=0)
+        )  # (N_eval, pred_steps, d_f)
+
+        if is_global_zero:
+            metric_tensor_averaged = torch.mean(metric_tensor, dim=0)
+            # (pred_steps, d_f)
+
+            # Take square root after all averaging to change MSE to RMSE
+            if "mse" in metric_name:
+                metric_tensor_averaged = torch.sqrt(metric_tensor_averaged)
+                metric_name = metric_name.replace("mse", "rmse")
+
+            # NOTE: we here assume rescaling for all metrics is linear
+            metric_rescaled = metric_tensor_averaged * state_std
+            # (pred_steps, d_f)
+            log_dict.update(
+                create_metric_log_dict(
+                    metric_tensor=metric_rescaled,
+                    prefix=prefix,
+                    metric_name=metric_name,
+                    datastore=datastore,
+                    save_dir=save_dir,
+                    metrics_watch=metrics_watch,
+                    var_leads_metrics_watch=var_leads_metrics_watch,
+                )
+            )
+
+    # Ensure that log_dict has structure for
+    # logging as dict(str, plt.Figure) or dict(str, float/torch.Tensor)
+    assert all(
+        isinstance(key, str)
+        and (
+            isinstance(value, plt.Figure)
+            or isinstance(value, (torch.Tensor, float, int))
+        )
+        for key, value in log_dict.items()
+    )
+
+    return log_dict

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -1,14 +1,11 @@
 # Standard library
 import os
-import warnings
 from typing import Any, Dict, List
 
 # Third-party
 import matplotlib.pyplot as plt
-import numpy as np
 import pytorch_lightning as pl
 import torch
-import xarray as xr
 
 # First-party
 from neural_lam.utils import get_integer_time
@@ -18,7 +15,6 @@ from .. import metrics, vis
 from ..config import NeuralLAMConfig
 from ..datastore import BaseDatastore
 from ..loss_weighting import get_state_feature_weighting
-from ..weather_dataset import WeatherDataset
 
 
 class ARModel(pl.LightningModule):
@@ -159,44 +155,6 @@ class ARModel(pl.LightningModule):
         self.time_step_int, self.time_step_unit = get_integer_time(
             self._datastore.step_length
         )
-
-    def _create_dataarray_from_tensor(
-        self,
-        tensor: torch.Tensor,
-        time: torch.Tensor,
-        split: str,
-        category: str,
-    ) -> xr.DataArray:
-        """
-        Create an `xr.DataArray` from a tensor, with the correct dimensions and
-        coordinates to match the datastore used by the model. This function in
-        in effect is the inverse of what is returned by
-        `WeatherDataset.__getitem__`.
-
-        Parameters
-        ----------
-        tensor : torch.Tensor
-            The tensor to convert to a `xr.DataArray` with dimensions [time,
-            grid_index, feature]. The tensor will be copied to the CPU if it is
-            not already there.
-        time : torch.Tensor
-            The time index or indices for the data, given as tensor representing
-            epoch time in nanoseconds. The tensor will be
-            copied to the CPU memory if they are not already there.
-        split : str
-            The split of the data, either 'train', 'val', or 'test'
-        category : str
-            The category of the data, either 'state' or 'forcing'
-        """
-        # TODO: creating an instance of WeatherDataset here on every call is
-        # not how this should be done but whether WeatherDataset should be
-        # provided to ARModel or where to put plotting still needs discussion
-        weather_dataset = WeatherDataset(datastore=self._datastore, split=split)
-        time = np.array(time.cpu(), dtype="datetime64[ns]")
-        da = weather_dataset.create_dataarray_from_tensor(
-            tensor=tensor, time=time, category=category
-        )
-        return da
 
     def configure_optimizers(self):
         opt = torch.optim.AdamW(
@@ -456,181 +414,22 @@ class ARModel(pl.LightningModule):
                 self.n_example_pred - self.plotted_examples,
             )
 
-            self.plot_examples(
-                batch,
-                n_additional_examples,
+            # Local
+            from ..evaluation import plot_examples
+
+            self.plotted_examples = plot_examples(
+                datastore=self._datastore,
                 prediction=prediction,
+                target=target,
+                time=batch[3],
+                n_examples=n_additional_examples,
                 split="test",
+                plotted_examples=self.plotted_examples,
+                state_std=self.state_std,
+                state_mean=self.state_mean,
+                save_dir=self.logger.save_dir if self.logger else "",
+                logger=self.logger,
             )
-
-    def plot_examples(self, batch, n_examples, split, prediction=None):
-        """
-        Plot the first n_examples forecasts from batch
-
-        batch: batch with data to plot corresponding forecasts for n_examples:
-        number of forecasts to plot prediction: (B, pred_steps, num_grid_nodes,
-        d_f), existing prediction.
-            Generate if None.
-        """
-        if prediction is None:
-            prediction, target, _, _ = self.common_step(batch)
-
-        target = batch[1]
-        time = batch[3]
-
-        # Rescale to original data scale
-        prediction_rescaled = prediction * self.state_std + self.state_mean
-        target_rescaled = target * self.state_std + self.state_mean
-
-        # Iterate over the examples
-        for pred_slice, target_slice, time_slice in zip(
-            prediction_rescaled[:n_examples],
-            target_rescaled[:n_examples],
-            time[:n_examples],
-        ):
-            # Each slice is (pred_steps, num_grid_nodes, d_f)
-            self.plotted_examples += 1  # Increment already here
-
-            da_prediction = self._create_dataarray_from_tensor(
-                tensor=pred_slice,
-                time=time_slice,
-                split=split,
-                category="state",
-            ).unstack("grid_index")
-            da_target = self._create_dataarray_from_tensor(
-                tensor=target_slice,
-                time=time_slice,
-                split=split,
-                category="state",
-            ).unstack("grid_index")
-
-            var_vmin = (
-                torch.minimum(
-                    pred_slice.flatten(0, 1).min(dim=0)[0],
-                    target_slice.flatten(0, 1).min(dim=0)[0],
-                )
-                .cpu()
-                .numpy()
-            )  # (d_f,)
-            var_vmax = (
-                torch.maximum(
-                    pred_slice.flatten(0, 1).max(dim=0)[0],
-                    target_slice.flatten(0, 1).max(dim=0)[0],
-                )
-                .cpu()
-                .numpy()
-            )  # (d_f,)
-            var_vranges = list(zip(var_vmin, var_vmax))
-
-            # Iterate over prediction horizon time steps
-            for t_i, _ in enumerate(zip(pred_slice, target_slice), start=1):
-                # Create one figure per variable at this time step
-                var_figs = [
-                    vis.plot_prediction(
-                        datastore=self._datastore,
-                        title=f"{var_name} ({var_unit}), "
-                        f"t={t_i} ({(self.time_step_int * t_i)}"
-                        f"{self.time_step_unit})",
-                        vrange=var_vrange,
-                        da_prediction=da_prediction.isel(
-                            state_feature=var_i, time=t_i - 1
-                        ).squeeze(),
-                        da_target=da_target.isel(
-                            state_feature=var_i, time=t_i - 1
-                        ).squeeze(),
-                    )
-                    for var_i, (var_name, var_unit, var_vrange) in enumerate(
-                        zip(
-                            self._datastore.get_vars_names("state"),
-                            self._datastore.get_vars_units("state"),
-                            var_vranges,
-                        )
-                    )
-                ]
-
-                example_i = self.plotted_examples
-
-                for var_name, fig in zip(
-                    self._datastore.get_vars_names("state"), var_figs
-                ):
-
-                    # We need treat logging images differently for different
-                    # loggers. WANDB can log multiple images to the same key,
-                    # while other loggers, as MLFlow, need unique keys for
-                    # each image.
-                    if isinstance(self.logger, pl.loggers.WandbLogger):
-                        key = f"{var_name}_example_{example_i}"
-                    else:
-                        key = f"{var_name}_example"
-
-                    if hasattr(self.logger, "log_image"):
-                        self.logger.log_image(key=key, images=[fig], step=t_i)
-                    else:
-                        warnings.warn(
-                            f"{self.logger} does not support image logging."
-                        )
-
-                plt.close(
-                    "all"
-                )  # Close all figs for this time step, saves memory
-
-            # Save pred and target as .pt files
-            torch.save(
-                pred_slice.cpu(),
-                os.path.join(
-                    self.logger.save_dir,
-                    f"example_pred_{self.plotted_examples}.pt",
-                ),
-            )
-            torch.save(
-                target_slice.cpu(),
-                os.path.join(
-                    self.logger.save_dir,
-                    f"example_target_{self.plotted_examples}.pt",
-                ),
-            )
-
-    def create_metric_log_dict(self, metric_tensor, prefix, metric_name):
-        """
-        Put together a dict with everything to log for one metric. Also saves
-        plots as pdf and csv if using test prefix.
-
-        metric_tensor: (pred_steps, d_f), metric values per time and variable
-        prefix: string, prefix to use for logging metric_name: string, name of
-        the metric
-
-        Return: log_dict: dict with everything to log for given metric
-        """
-        log_dict = {}
-        metric_fig = vis.plot_error_map(
-            errors=metric_tensor,
-            datastore=self._datastore,
-        )
-        full_log_name = f"{prefix}_{metric_name}"
-        log_dict[full_log_name] = metric_fig
-
-        if prefix == "test":
-            # Save pdf
-            metric_fig.savefig(
-                os.path.join(self.logger.save_dir, f"{full_log_name}.pdf")
-            )
-            # Save errors also as csv
-            np.savetxt(
-                os.path.join(self.logger.save_dir, f"{full_log_name}.csv"),
-                metric_tensor.cpu().numpy(),
-                delimiter=",",
-            )
-
-        # Check if metrics are watched, log exact values for specific vars
-        var_names = self._datastore.get_vars_names(category="state")
-        if full_log_name in self.args.metrics_watch:
-            for var_i, timesteps in self.args.var_leads_metrics_watch.items():
-                var_name = var_names[var_i]
-                for step in timesteps:
-                    key = f"{full_log_name}_{var_name}_step_{step}"
-                    log_dict[key] = metric_tensor[step - 1, var_i]
-
-        return log_dict
 
     def aggregate_and_plot_metrics(self, metrics_dict, prefix):
         """
@@ -640,50 +439,34 @@ class ARModel(pl.LightningModule):
             with step-evals.
         prefix: string, prefix to use for logging
         """
-        log_dict = {}
-        for metric_name, metric_val_list in metrics_dict.items():
-            metric_tensor = self.all_gather_cat(
-                torch.cat(metric_val_list, dim=0)
-            )  # (N_eval, pred_steps, d_f)
+        # Local
+        from ..evaluation import evaluate_metrics
 
-            if self.trainer.is_global_zero:
-                metric_tensor_averaged = torch.mean(metric_tensor, dim=0)
-                # (pred_steps, d_f)
-
-                # Take square root after all averaging to change MSE to RMSE
-                if "mse" in metric_name:
-                    metric_tensor_averaged = torch.sqrt(metric_tensor_averaged)
-                    metric_name = metric_name.replace("mse", "rmse")
-
-                # NOTE: we here assume rescaling for all metrics is linear
-                metric_rescaled = metric_tensor_averaged * self.state_std
-                # (pred_steps, d_f)
-                log_dict.update(
-                    self.create_metric_log_dict(
-                        metric_rescaled, prefix, metric_name
-                    )
-                )
-
-        # Ensure that log_dict has structure for
-        # logging as dict(str, plt.Figure)
-        assert all(
-            isinstance(key, str) and isinstance(value, plt.Figure)
-            for key, value in log_dict.items()
+        log_dict = evaluate_metrics(
+            metrics_dict=metrics_dict,
+            prefix=prefix,
+            state_std=self.state_std,
+            datastore=self._datastore,
+            save_dir=self.logger.save_dir if self.logger else "",
+            metrics_watch=self.args.metrics_watch,
+            var_leads_metrics_watch=self.args.var_leads_metrics_watch,
+            all_gather_cat_fn=self.all_gather_cat,
+            is_global_zero=self.trainer.is_global_zero,
         )
 
         if self.trainer.is_global_zero and not self.trainer.sanity_checking:
 
             current_epoch = self.trainer.current_epoch
 
-            for key, figure in log_dict.items():
-                # For other loggers than wandb, add epoch to key.
-                # Wandb can log multiple images to the same key, while other
-                # loggers, such as MLFlow need unique keys for each image.
-                if not isinstance(self.logger, pl.loggers.WandbLogger):
-                    key = f"{key}-{current_epoch}"
+            for key, val in log_dict.items():
+                if isinstance(val, plt.Figure):
+                    if not isinstance(self.logger, pl.loggers.WandbLogger):
+                        key = f"{key}-{current_epoch}"
 
-                if hasattr(self.logger, "log_image"):
-                    self.logger.log_image(key=key, images=[figure])
+                    if hasattr(self.logger, "log_image"):
+                        self.logger.log_image(key=key, images=[val])
+                else:
+                    self.log(key, val, sync_dist=False)
 
             plt.close("all")  # Close all figs
 


### PR DESCRIPTION
## Describe your changes

Extracted plotting and metric evaluation code from the [ARModel](cci:2://file:///c:/Users/singh/Documents/GitHub/neural-lam/neural_lam/models/ar_model.py:19:0-553:63) class into stateless functions. This involves:
- Moving [_create_dataarray_from_tensor](cci:1://file:///c:/Users/singh/Documents/GitHub/neural-lam/neural_lam/models/ar_model.py:162:4-198:17), [plot_examples](cci:1://file:///c:/Users/singh/Documents/GitHub/neural-lam/neural_lam/evaluation.py:53:0-199:27), [create_metric_log_dict](cci:1://file:///c:/Users/singh/Documents/GitHub/neural-lam/neural_lam/models/ar_model.py:592:4-632:23), and the inner logic of [aggregate_and_plot_metrics](cci:1://file:///c:/Users/singh/Documents/GitHub/neural-lam/neural_lam/models/ar_model.py:433:4-470:47) to a new module [neural_lam/evaluation.py](cci:7://file:///c:/Users/singh/Documents/GitHub/neural-lam/neural_lam/evaluation.py:0:0-0:0).
- Refactoring [ARModel](cci:2://file:///c:/Users/singh/Documents/GitHub/neural-lam/neural_lam/models/ar_model.py:19:0-553:63) to consume these stateless functions directly instead of relying on class properties.
- Removing unused imports after the extraction.

This is part of a larger ongoing refactoring effort to break up the monolithic [ARModel](cci:2://file:///c:/Users/singh/Documents/GitHub/neural-lam/neural_lam/models/ar_model.py:19:0-553:63) into more modular, testable, and reusable components. 

No new dependencies are required for this change.

## Issue Link
#49 

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [x] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
