### PR TITLE
Add resumable inference via sample range and skip-existing example outputs

### DIFF
--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -491,6 +491,18 @@ class ARModel(pl.LightningModule):
             # Each slice is (pred_steps, num_grid_nodes, d_f)
             self.plotted_examples += 1  # Increment already here
 
+            # Skip if example files already exist (resumable inference)
+            pred_path = os.path.join(
+                self.logger.save_dir,
+                f"example_pred_{self.plotted_examples}.pt",
+            )
+            target_path = os.path.join(
+                self.logger.save_dir,
+                f"example_target_{self.plotted_examples}.pt",
+            )
+            if os.path.exists(pred_path) and os.path.exists(target_path):
+                continue
+
             da_prediction = self._create_dataarray_from_tensor(
                 tensor=pred_slice,
                 time=time_slice,

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -489,19 +489,22 @@ class ARModel(pl.LightningModule):
             time[:n_examples],
         ):
             # Each slice is (pred_steps, num_grid_nodes, d_f)
-            self.plotted_examples += 1  # Increment already here
 
             # Skip if example files already exist (resumable inference)
-            pred_path = os.path.join(
-                self.logger.save_dir,
-                f"example_pred_{self.plotted_examples}.pt",
-            )
-            target_path = os.path.join(
-                self.logger.save_dir,
-                f"example_target_{self.plotted_examples}.pt",
-            )
-            if os.path.exists(pred_path) and os.path.exists(target_path):
-                continue
+            if self.logger is not None and self.logger.save_dir is not None:
+                pred_path = os.path.join(
+                    self.logger.save_dir,
+                    f"example_pred_{self.plotted_examples + 1}.pt",
+                )
+                target_path = os.path.join(
+                    self.logger.save_dir,
+                    f"example_target_{self.plotted_examples + 1}.pt",
+                )
+                if os.path.exists(pred_path) and os.path.exists(target_path):
+                    self.plotted_examples += 1
+                    continue
+
+            self.plotted_examples += 1  # Increment after skip check
 
             da_prediction = self._create_dataarray_from_tensor(
                 tensor=pred_slice,

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -170,6 +170,21 @@ def main(input_args=None):
         default=1,
         help="Number of example predictions to plot during evaluation",
     )
+    parser.add_argument(
+        "--eval_sample_start",
+        type=int,
+        default=0,
+        help="Start index (inclusive) of samples to evaluate. "
+        "Use with --eval_sample_end to process a subset for "
+        "resumable inference.",
+    )
+    parser.add_argument(
+        "--eval_sample_end",
+        type=int,
+        default=None,
+        help="End index (exclusive) of samples to evaluate. "
+        "If None, process all samples from --eval_sample_start onwards.",
+    )
 
     # Logger Settings
     parser.add_argument(
@@ -266,6 +281,8 @@ def main(input_args=None):
         batch_size=args.batch_size,
         num_workers=args.num_workers,
         eval_split=args.eval or "test",
+        eval_sample_start=args.eval_sample_start,
+        eval_sample_end=args.eval_sample_end,
     )
 
     # Instantiate model + trainer

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -615,6 +615,8 @@ class WeatherDataModule(pl.LightningDataModule):
         batch_size: int = 4,
         num_workers: int = 16,
         eval_split: str = "test",
+        eval_sample_start: int = 0,
+        eval_sample_end: int = None,
     ):
         super().__init__()
         self._datastore = datastore
@@ -630,6 +632,8 @@ class WeatherDataModule(pl.LightningDataModule):
         self.test_dataset = None
         self.multiprocessing_context: Union[str, None] = None
         self.eval_split = eval_split
+        self.eval_sample_start = eval_sample_start
+        self.eval_sample_end = eval_sample_end
         if num_workers > 0:
             # default to spawn for now, as the default on linux "fork" hangs
             # when using dask (which the npyfilesmeps datastore uses)
@@ -663,6 +667,23 @@ class WeatherDataModule(pl.LightningDataModule):
                 num_past_forcing_steps=self.num_past_forcing_steps,
                 num_future_forcing_steps=self.num_future_forcing_steps,
             )
+            # Apply sample range subsetting for resumable inference
+            if (
+                self.eval_sample_start > 0
+                or self.eval_sample_end is not None
+            ):
+                total = len(self.test_dataset)
+                end = (
+                    self.eval_sample_end
+                    if self.eval_sample_end is not None
+                    else total
+                )
+                indices = range(
+                    self.eval_sample_start, min(end, total)
+                )
+                self.test_dataset = torch.utils.data.Subset(
+                    self.test_dataset, indices
+                )
 
     def train_dataloader(self):
         """Load train dataset."""

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -634,6 +634,14 @@ class WeatherDataModule(pl.LightningDataModule):
         self.eval_split = eval_split
         self.eval_sample_start = eval_sample_start
         self.eval_sample_end = eval_sample_end
+        if (
+            eval_sample_end is not None
+            and eval_sample_end <= eval_sample_start
+        ):
+            raise ValueError(
+                f"eval_sample_end ({eval_sample_end}) must be greater than "
+                f"eval_sample_start ({eval_sample_start})."
+            )
         if num_workers > 0:
             # default to spawn for now, as the default on linux "fork" hangs
             # when using dask (which the npyfilesmeps datastore uses)


### PR DESCRIPTION
Adds --eval_sample_start and --eval_sample_end CLI arguments to subset evaluation split. Also skips example prediction plotting if the corresponding .pt files already exist.

## Describe your changes

This PR adds resumable inference support for evaluation runs (`--eval val` / `--eval test`).

Two complementary improvements are introduced:

1. **Sample range parameters**
   - Added `--eval_sample_start` (default: 0)
   - Added `--eval_sample_end` (default: None)
   These allow users to evaluate only a subset of samples during inference.

2. **Skip existing example outputs**
   - Before plotting example predictions, the code checks whether
     `example_pred_{n}.pt` and `example_target_{n}.pt` already exist.
   - If both files exist, the example is skipped to avoid overwriting.

### Motivation and Context

When running inference on SLURM, jobs may time out before all evaluation samples are processed. Restarting inference currently:

- Re-processes all samples from scratch
- Overwrites existing example prediction `.pt` files
- Will become problematic once evaluation outputs are written to Zarr

This change allows:
- Splitting evaluation across multiple SLURM allocations
- Safely resuming inference without overwriting previously generated outputs
- Maintaining full backward compatibility (default behavior unchanged)

### Dependencies

No new dependencies were introduced.

---

## Issue Link

Closes #247   

---

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

---

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes (not required unless maintainers prefer CLI options documented)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form.
- [ ] I have requested a reviewer and an assignee (if applicable)

---

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:

- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

---

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section reflecting type of change:
  - *added*: when you have added new functionality

---

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone.
- [ ] author has added an entry to the changelog
- Once the PR is ready to be merged, squash commits and merge the PR.