### PR TITLE
[Feat] Implement area weights for grid-point averaging

### DIFF
--- a/neural_lam/config.py
+++ b/neural_lam/config.py
@@ -103,6 +103,8 @@ class TrainingConfig:
         default_factory=OutputClamping
     )
 
+    use_area_weights: bool = False
+
 
 @dataclasses.dataclass
 class NeuralLAMConfig(dataclass_wizard.JSONWizard, dataclass_wizard.YAMLWizard):

--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -97,10 +97,21 @@ def mask_and_reduce_metric(
     if average_grid:  # Reduce grid first
         if grid_weights is not None:
             # Weighted mean over grid dimension
-            # Reshape weights for broadcasting: (..., N', 1)
-            w = grid_weights.unsqueeze(-1)  # (N', 1)
+            # Reshape weights for broadcasting: (N', 1)
+            w = grid_weights.to(
+                device=metric_entry_vals.device,
+                dtype=metric_entry_vals.dtype,
+            ).unsqueeze(
+                -1
+            )  # (N', 1)
             # Normalize weights to sum to 1 over the (possibly masked) grid
-            w = w / w.sum(dim=-2, keepdim=True)
+            w_sum = w.sum(dim=-2, keepdim=True)
+            if w_sum.item() <= 0:
+                raise ValueError(
+                    "Sum of grid weights is non-positive after masking. "
+                    "All weighted grid points may have been masked out."
+                )
+            w = w / w_sum
             metric_entry_vals = torch.sum(
                 metric_entry_vals * w, dim=-2
             )  # (..., d_state)

--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -1,5 +1,7 @@
 # Third-party
+import numpy as np
 import torch
+from cartopy import crs as ccrs
 
 
 def get_metric(metric_name):
@@ -18,7 +20,51 @@ def get_metric(metric_name):
     return DEFINED_METRICS[metric_name_lower]
 
 
-def mask_and_reduce_metric(metric_entry_vals, mask, average_grid, sum_vars):
+def compute_area_weights(datastore):
+    """
+    Compute area weights for each grid point based on the cosine of the
+    latitude. This accounts for the fact that grid cells at higher latitudes
+    cover less surface area than cells near the equator.
+
+    The weights are normalized so that they sum to the number of grid points
+    (i.e. the mean weight is 1.0), so that using these weights is equivalent
+    to an unweighted mean when all latitudes are equal.
+
+    Parameters
+    ----------
+    datastore : BaseDatastore
+        The datastore providing grid coordinates and projection information.
+
+    Returns
+    -------
+    torch.Tensor
+        Area weights of shape (N,), where N is the number of grid points.
+        Each weight is proportional to cos(latitude) and the weights are
+        normalized to sum to N.
+    """
+    # Get projected x, y coordinates for state grid points
+    xy = datastore.get_xy(category="state", stacked=True)  # (N, 2)
+
+    # Transform projected coordinates to geographic lat/lon
+    lonlat = ccrs.PlateCarree().transform_points(
+        src_crs=datastore.coords_projection,
+        x=xy[:, 0],
+        y=xy[:, 1],
+    )  # (N, 3) -> [lon, lat, z]
+
+    lat_rad = np.deg2rad(lonlat[:, 1])  # latitude in radians
+    cos_lat = np.cos(lat_rad)
+
+    # Normalize weights so they sum to N (mean weight = 1.0)
+    n_points = len(cos_lat)
+    weights = cos_lat * (n_points / cos_lat.sum())
+
+    return torch.tensor(weights, dtype=torch.float32)
+
+
+def mask_and_reduce_metric(
+    metric_entry_vals, mask, average_grid, sum_vars, grid_weights=None
+):
     """
     Masks and (optionally) reduces entry-wise metric values
 
@@ -26,9 +72,13 @@ def mask_and_reduce_metric(metric_entry_vals, mask, average_grid, sum_vars):
         but broadcastable
     metric_entry_vals: (..., N, d_state), prediction
     mask: (N,), boolean mask describing which grid nodes to use in metric
-    average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
+    average_grid: boolean, if grid dimension -2 should be reduced
+        (mean over N). If grid_weights are provided, uses weighted mean.
     sum_vars: boolean, if variable dimension -1 should be reduced (sum
         over d_state)
+    grid_weights: (N,) or None, optional area-based weights for each grid
+        point. When provided and average_grid=True, a weighted mean is used
+        instead of a simple mean. The weights are applied after masking.
 
     Returns:
     metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
@@ -39,12 +89,25 @@ def mask_and_reduce_metric(metric_entry_vals, mask, average_grid, sum_vars):
         metric_entry_vals = metric_entry_vals[
             ..., mask, :
         ]  # (..., N', d_state)
+        # Also mask the grid weights if provided
+        if grid_weights is not None:
+            grid_weights = grid_weights[mask]  # (N',)
 
     # Optionally reduce last two dimensions
     if average_grid:  # Reduce grid first
-        metric_entry_vals = torch.mean(
-            metric_entry_vals, dim=-2
-        )  # (..., d_state)
+        if grid_weights is not None:
+            # Weighted mean over grid dimension
+            # Reshape weights for broadcasting: (..., N', 1)
+            w = grid_weights.unsqueeze(-1)  # (N', 1)
+            # Normalize weights to sum to 1 over the (possibly masked) grid
+            w = w / w.sum(dim=-2, keepdim=True)
+            metric_entry_vals = torch.sum(
+                metric_entry_vals * w, dim=-2
+            )  # (..., d_state)
+        else:
+            metric_entry_vals = torch.mean(
+                metric_entry_vals, dim=-2
+            )  # (..., d_state)
     if sum_vars:  # Reduce vars second
         metric_entry_vals = torch.sum(
             metric_entry_vals, dim=-1
@@ -53,7 +116,15 @@ def mask_and_reduce_metric(metric_entry_vals, mask, average_grid, sum_vars):
     return metric_entry_vals
 
 
-def wmse(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
+def wmse(
+    pred,
+    target,
+    pred_std,
+    mask=None,
+    average_grid=True,
+    sum_vars=True,
+    grid_weights=None,
+):
     """
     Weighted Mean Squared Error
 
@@ -66,6 +137,8 @@ def wmse(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
     sum_vars: boolean, if variable dimension -1 should be reduced (sum
         over d_state)
+    grid_weights: (N,) or None, optional area-based weights for each grid
+        point
 
     Returns:
     metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
@@ -81,10 +154,19 @@ def wmse(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
         mask=mask,
         average_grid=average_grid,
         sum_vars=sum_vars,
+        grid_weights=grid_weights,
     )
 
 
-def mse(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
+def mse(
+    pred,
+    target,
+    pred_std,
+    mask=None,
+    average_grid=True,
+    sum_vars=True,
+    grid_weights=None,
+):
     """
     (Unweighted) Mean Squared Error
 
@@ -97,6 +179,8 @@ def mse(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
     sum_vars: boolean, if variable dimension -1 should be reduced (sum
         over d_state)
+    grid_weights: (N,) or None, optional area-based weights for each grid
+        point
 
     Returns:
     metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
@@ -104,11 +188,25 @@ def mse(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     """
     # Replace pred_std with constant ones
     return wmse(
-        pred, target, torch.ones_like(pred_std), mask, average_grid, sum_vars
+        pred,
+        target,
+        torch.ones_like(pred_std),
+        mask,
+        average_grid,
+        sum_vars,
+        grid_weights=grid_weights,
     )
 
 
-def wmae(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
+def wmae(
+    pred,
+    target,
+    pred_std,
+    mask=None,
+    average_grid=True,
+    sum_vars=True,
+    grid_weights=None,
+):
     """
     Weighted Mean Absolute Error
 
@@ -121,6 +219,8 @@ def wmae(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
     sum_vars: boolean, if variable dimension -1 should be reduced (sum
         over d_state)
+    grid_weights: (N,) or None, optional area-based weights for each grid
+        point
 
     Returns:
     metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
@@ -136,10 +236,19 @@ def wmae(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
         mask=mask,
         average_grid=average_grid,
         sum_vars=sum_vars,
+        grid_weights=grid_weights,
     )
 
 
-def mae(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
+def mae(
+    pred,
+    target,
+    pred_std,
+    mask=None,
+    average_grid=True,
+    sum_vars=True,
+    grid_weights=None,
+):
     """
     (Unweighted) Mean Absolute Error
 
@@ -152,6 +261,8 @@ def mae(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
     sum_vars: boolean, if variable dimension -1 should be reduced (sum
         over d_state)
+    grid_weights: (N,) or None, optional area-based weights for each grid
+        point
 
     Returns:
     metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
@@ -159,11 +270,25 @@ def mae(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     """
     # Replace pred_std with constant ones
     return wmae(
-        pred, target, torch.ones_like(pred_std), mask, average_grid, sum_vars
+        pred,
+        target,
+        torch.ones_like(pred_std),
+        mask,
+        average_grid,
+        sum_vars,
+        grid_weights=grid_weights,
     )
 
 
-def nll(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
+def nll(
+    pred,
+    target,
+    pred_std,
+    mask=None,
+    average_grid=True,
+    sum_vars=True,
+    grid_weights=None,
+):
     """
     Negative Log Likelihood loss, for isotropic Gaussian likelihood
 
@@ -176,6 +301,8 @@ def nll(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
     sum_vars: boolean, if variable dimension -1 should be reduced (sum
         over d_state)
+    grid_weights: (N,) or None, optional area-based weights for each grid
+        point
 
     Returns:
     metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
@@ -186,12 +313,22 @@ def nll(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     entry_nll = -dist.log_prob(target)  # (..., N, d_state)
 
     return mask_and_reduce_metric(
-        entry_nll, mask=mask, average_grid=average_grid, sum_vars=sum_vars
+        entry_nll,
+        mask=mask,
+        average_grid=average_grid,
+        sum_vars=sum_vars,
+        grid_weights=grid_weights,
     )
 
 
 def crps_gauss(
-    pred, target, pred_std, mask=None, average_grid=True, sum_vars=True
+    pred,
+    target,
+    pred_std,
+    mask=None,
+    average_grid=True,
+    sum_vars=True,
+    grid_weights=None,
 ):
     """
     (Negative) Continuous Ranked Probability Score (CRPS)
@@ -206,6 +343,8 @@ def crps_gauss(
     average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
     sum_vars: boolean, if variable dimension -1 should be reduced (sum
         over d_state)
+    grid_weights: (N,) or None, optional area-based weights for each grid
+        point
 
     Returns:
     metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
@@ -223,7 +362,11 @@ def crps_gauss(
     )  # (..., N, d_state)
 
     return mask_and_reduce_metric(
-        entry_crps, mask=mask, average_grid=average_grid, sum_vars=sum_vars
+        entry_crps,
+        mask=mask,
+        average_grid=average_grid,
+        sum_vars=sum_vars,
+        grid_weights=grid_weights,
     )
 
 

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -136,11 +136,14 @@ class ARModel(pl.LightningModule):
             "interior_mask", 1.0 - self.boundary_mask, persistent=False
         )  # (num_grid_nodes, 1), 1 for non-border
 
-        # Compute area weights for grid-point averaging in metrics
-        area_weights = metrics.compute_area_weights(datastore)
-        self.register_buffer(
-            "grid_weights", area_weights, persistent=False
-        )  # (num_grid_nodes,)
+        # Optionally compute area weights for grid-point averaging
+        if config.training.use_area_weights:
+            area_weights = metrics.compute_area_weights(datastore)
+            self.register_buffer(
+                "grid_weights", area_weights, persistent=False
+            )  # (num_grid_nodes,)
+        else:
+            self.grid_weights = None
 
         self.val_metrics: Dict[str, List] = {
             "mse": [],

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -136,6 +136,12 @@ class ARModel(pl.LightningModule):
             "interior_mask", 1.0 - self.boundary_mask, persistent=False
         )  # (num_grid_nodes, 1), 1 for non-border
 
+        # Compute area weights for grid-point averaging in metrics
+        area_weights = metrics.compute_area_weights(datastore)
+        self.register_buffer(
+            "grid_weights", area_weights, persistent=False
+        )  # (num_grid_nodes,)
+
         self.val_metrics: Dict[str, List] = {
             "mse": [],
         }
@@ -303,7 +309,11 @@ class ARModel(pl.LightningModule):
         # Compute loss
         batch_loss = torch.mean(
             self.loss(
-                prediction, target, pred_std, mask=self.interior_mask_bool
+                prediction,
+                target,
+                pred_std,
+                mask=self.interior_mask_bool,
+                grid_weights=self.grid_weights,
             )
         )  # mean over unrolled times and batch
 
@@ -339,7 +349,11 @@ class ARModel(pl.LightningModule):
 
         time_step_loss = torch.mean(
             self.loss(
-                prediction, target, pred_std, mask=self.interior_mask_bool
+                prediction,
+                target,
+                pred_std,
+                mask=self.interior_mask_bool,
+                grid_weights=self.grid_weights,
             ),
             dim=0,
         )  # (time_steps-1)
@@ -367,6 +381,7 @@ class ARModel(pl.LightningModule):
             pred_std,
             mask=self.interior_mask_bool,
             sum_vars=False,
+            grid_weights=self.grid_weights,
         )  # (B, pred_steps, d_f)
         self.val_metrics["mse"].append(entry_mses)
 
@@ -393,7 +408,11 @@ class ARModel(pl.LightningModule):
 
         time_step_loss = torch.mean(
             self.loss(
-                prediction, target, pred_std, mask=self.interior_mask_bool
+                prediction,
+                target,
+                pred_std,
+                mask=self.interior_mask_bool,
+                grid_weights=self.grid_weights,
             ),
             dim=0,
         )  # (time_steps-1,)
@@ -425,6 +444,7 @@ class ARModel(pl.LightningModule):
                 pred_std,
                 mask=self.interior_mask_bool,
                 sum_vars=False,
+                grid_weights=self.grid_weights,
             )  # (B, pred_steps, d_f)
             self.test_metrics[metric_name].append(batch_metric_vals)
 
@@ -437,7 +457,11 @@ class ARModel(pl.LightningModule):
 
         # Save per-sample spatial loss for specific times
         spatial_loss = self.loss(
-            prediction, target, pred_std, average_grid=False
+            prediction,
+            target,
+            pred_std,
+            average_grid=False,
+            grid_weights=self.grid_weights,
         )  # (B, pred_steps, num_grid_nodes)
         log_spatial_losses = spatial_loss[
             :, [step - 1 for step in self.args.val_steps_to_log]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,425 @@
+# Third-party
+import pytest
+import torch
+
+# First-party
+from neural_lam import metrics
+from tests.dummy_datastore import DummyDatastore
+
+
+# ============================================================
+# Fixtures
+# ============================================================
+@pytest.fixture
+def dummy_data():
+    """Create simple dummy tensors for metric testing."""
+    N = 10  # grid points
+    d_state = 3  # state features
+    B = 2  # batch size
+
+    pred = torch.randn(B, N, d_state)
+    target = torch.randn(B, N, d_state)
+    pred_std = torch.abs(torch.randn(B, N, d_state)) + 0.1
+    return pred, target, pred_std
+
+
+@pytest.fixture
+def uniform_weights():
+    """Uniform weights (should give same result as no weights)."""
+    N = 10
+    return torch.ones(N)
+
+
+@pytest.fixture
+def non_uniform_weights():
+    """Non-uniform weights simulating latitude-dependent area."""
+    N = 10
+    # Simulate cos(latitude) pattern: larger weights near equator
+    lats = torch.linspace(-60, 60, N)
+    weights = torch.cos(torch.deg2rad(lats))
+    # Normalize so weights sum to N
+    weights = weights * (N / weights.sum())
+    return weights
+
+
+@pytest.fixture
+def mask():
+    """Boolean mask selecting a subset of grid points."""
+    N = 10
+    mask = torch.zeros(N, dtype=torch.bool)
+    mask[:7] = True  # keep first 7 grid points
+    return mask
+
+
+# ============================================================
+# Test: backward compatibility (grid_weights=None)
+# ============================================================
+@pytest.mark.parametrize("metric_name", metrics.DEFINED_METRICS.keys())
+def test_no_weights_gives_same_result_as_before(metric_name, dummy_data):
+    """
+    When grid_weights=None (default), all metrics should produce the same
+    result as the original unweighted implementation.
+    """
+    pred, target, pred_std = dummy_data
+    metric_func = metrics.get_metric(metric_name)
+
+    result_no_kwarg = metric_func(pred, target, pred_std)
+    result_none = metric_func(pred, target, pred_std, grid_weights=None)
+
+    torch.testing.assert_close(result_no_kwarg, result_none)
+
+
+# ============================================================
+# Test: uniform weights == no weights
+# ============================================================
+@pytest.mark.parametrize("metric_name", metrics.DEFINED_METRICS.keys())
+def test_uniform_weights_equals_no_weights(
+    metric_name, dummy_data, uniform_weights
+):
+    """
+    Uniform weights (all ones) should produce the same result as no weights,
+    since the weighted mean with equal weights is the same as the arithmetic
+    mean.
+    """
+    pred, target, pred_std = dummy_data
+    metric_func = metrics.get_metric(metric_name)
+
+    result_no_weights = metric_func(pred, target, pred_std)
+    result_uniform = metric_func(
+        pred, target, pred_std, grid_weights=uniform_weights
+    )
+
+    torch.testing.assert_close(
+        result_no_weights, result_uniform, atol=1e-5, rtol=1e-5
+    )
+
+
+# ============================================================
+# Test: non-uniform weights differ from unweighted
+# ============================================================
+@pytest.mark.parametrize("metric_name", metrics.DEFINED_METRICS.keys())
+def test_non_uniform_weights_differ(
+    metric_name, dummy_data, non_uniform_weights
+):
+    """
+    Non-uniform weights should generally produce a different result than
+    no weights (unless by rare coincidence).
+    """
+    pred, target, pred_std = dummy_data
+    metric_func = metrics.get_metric(metric_name)
+
+    result_no_weights = metric_func(pred, target, pred_std)
+    result_weighted = metric_func(
+        pred, target, pred_std, grid_weights=non_uniform_weights
+    )
+
+    # The results should be a valid tensor (not NaN)
+    assert not torch.isnan(result_weighted).any()
+    # They should generally differ (we use a loose check — if they are
+    # identical bit-for-bit that would be extremely unlikely with random data)
+    # This is a soft assertion; we mainly verify correctness elsewhere.
+    assert result_weighted.shape == result_no_weights.shape
+
+
+# ============================================================
+# Test: mask_and_reduce_metric directly
+# ============================================================
+class TestMaskAndReduceMetric:
+    """Tests for the mask_and_reduce_metric helper function."""
+
+    def test_no_reduction(self):
+        """No masking, no averaging, no summing."""
+        vals = torch.randn(2, 10, 3)
+        result = metrics.mask_and_reduce_metric(
+            vals, mask=None, average_grid=False, sum_vars=False
+        )
+        torch.testing.assert_close(result, vals)
+
+    def test_mask_only(self):
+        """Masking without any reduction."""
+        vals = torch.randn(2, 10, 3)
+        mask = torch.zeros(10, dtype=torch.bool)
+        mask[:5] = True
+        result = metrics.mask_and_reduce_metric(
+            vals, mask=mask, average_grid=False, sum_vars=False
+        )
+        assert result.shape == (2, 5, 3)
+        torch.testing.assert_close(result, vals[:, :5, :])
+
+    def test_average_grid_no_weights(self):
+        """Average over grid with no weights (simple mean)."""
+        vals = torch.ones(2, 10, 3) * 5.0
+        result = metrics.mask_and_reduce_metric(
+            vals, mask=None, average_grid=True, sum_vars=False
+        )
+        assert result.shape == (2, 3)
+        torch.testing.assert_close(result, torch.ones(2, 3) * 5.0)
+
+    def test_average_grid_uniform_weights(self):
+        """Average over grid with uniform weights should equal simple mean."""
+        vals = torch.randn(2, 10, 3)
+        weights = torch.ones(10)
+        result_weighted = metrics.mask_and_reduce_metric(
+            vals,
+            mask=None,
+            average_grid=True,
+            sum_vars=False,
+            grid_weights=weights,
+        )
+        result_unweighted = metrics.mask_and_reduce_metric(
+            vals, mask=None, average_grid=True, sum_vars=False
+        )
+        torch.testing.assert_close(
+            result_weighted, result_unweighted, atol=1e-6, rtol=1e-6
+        )
+
+    def test_weighted_mean_correctness(self):
+        """Verify weighted mean is computed correctly."""
+        # 2 grid points, 1 feature
+        vals = torch.tensor([[[2.0], [4.0]]])  # (1, 2, 1)
+        # Weight grid point 0 twice as much as grid point 1
+        weights = torch.tensor([2.0, 1.0])
+        result = metrics.mask_and_reduce_metric(
+            vals,
+            mask=None,
+            average_grid=True,
+            sum_vars=False,
+            grid_weights=weights,
+        )
+        # Expected: (2*2 + 1*4) / (2+1) = 8/3
+        expected = torch.tensor([[8.0 / 3.0]])
+        torch.testing.assert_close(result, expected, atol=1e-6, rtol=1e-6)
+
+    def test_weighted_mean_with_mask(self):
+        """Verify weighted mean works correctly with masking."""
+        # 4 grid points, 1 feature
+        vals = torch.tensor([[[1.0], [2.0], [3.0], [4.0]]])  # (1, 4, 1)
+        weights = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        mask = torch.tensor([True, True, False, False])
+        result = metrics.mask_and_reduce_metric(
+            vals,
+            mask=mask,
+            average_grid=True,
+            sum_vars=False,
+            grid_weights=weights,
+        )
+        # After masking: vals=[1,2], weights=[1,2]
+        # Weighted mean: (1*1 + 2*2)/(1+2) = 5/3
+        expected = torch.tensor([[5.0 / 3.0]])
+        torch.testing.assert_close(result, expected, atol=1e-6, rtol=1e-6)
+
+    def test_weights_not_applied_when_average_grid_false(self):
+        """When average_grid=False, weights should have no effect."""
+        vals = torch.randn(2, 10, 3)
+        weights = torch.randn(10).abs() + 0.1
+        result_weighted = metrics.mask_and_reduce_metric(
+            vals,
+            mask=None,
+            average_grid=False,
+            sum_vars=False,
+            grid_weights=weights,
+        )
+        result_unweighted = metrics.mask_and_reduce_metric(
+            vals, mask=None, average_grid=False, sum_vars=False
+        )
+        torch.testing.assert_close(result_weighted, result_unweighted)
+
+    def test_sum_vars_after_weighted_grid(self):
+        """Verify sum_vars works after weighted grid averaging."""
+        vals = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])  # (1, 2, 2)
+        weights = torch.tensor([1.0, 3.0])
+        result = metrics.mask_and_reduce_metric(
+            vals,
+            mask=None,
+            average_grid=True,
+            sum_vars=True,
+            grid_weights=weights,
+        )
+        # Weighted mean per feature:
+        #   feat0: (1*1 + 3*3)/(1+3) = 10/4 = 2.5
+        #   feat1: (1*2 + 3*4)/(1+3) = 14/4 = 3.5
+        # Sum: 2.5 + 3.5 = 6.0
+        expected = torch.tensor([6.0])
+        torch.testing.assert_close(result, expected, atol=1e-6, rtol=1e-6)
+
+
+# ============================================================
+# Test: compute_area_weights
+# ============================================================
+class TestComputeAreaWeights:
+    """Tests for the compute_area_weights utility function."""
+
+    def test_weights_shape(self):
+        """Weights should have shape (N,) matching grid points."""
+        datastore = DummyDatastore()
+        weights = metrics.compute_area_weights(datastore)
+        assert weights.shape == (datastore.num_grid_points,)
+
+    def test_weights_positive(self):
+        """All area weights should be positive."""
+        datastore = DummyDatastore()
+        weights = metrics.compute_area_weights(datastore)
+        assert (weights > 0).all()
+
+    def test_weights_sum_to_n(self):
+        """Weights should be normalized to sum to N (mean = 1)."""
+        datastore = DummyDatastore()
+        weights = metrics.compute_area_weights(datastore)
+        n = datastore.num_grid_points
+        torch.testing.assert_close(
+            weights.sum(),
+            torch.tensor(float(n)),
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    def test_weights_dtype(self):
+        """Weights should be float32."""
+        datastore = DummyDatastore()
+        weights = metrics.compute_area_weights(datastore)
+        assert weights.dtype == torch.float32
+
+
+# ============================================================
+# Test: metric functions with batch + time dimensions
+# ============================================================
+@pytest.mark.parametrize("metric_name", metrics.DEFINED_METRICS.keys())
+def test_metrics_with_batch_and_time_dims(metric_name):
+    """
+    Test that metrics handle batch (B) and time (T) dimensions correctly
+    with grid_weights, matching the shape used in ar_model.py.
+    """
+    B, T, N, d_state = 2, 4, 10, 3
+    pred = torch.randn(B, T, N, d_state)
+    target = torch.randn(B, T, N, d_state)
+    pred_std = torch.abs(torch.randn(B, T, N, d_state)) + 0.1
+    weights = torch.ones(N)
+
+    metric_func = metrics.get_metric(metric_name)
+
+    # With average_grid=True, sum_vars=True -> (B, T)
+    result = metric_func(pred, target, pred_std, grid_weights=weights)
+    assert result.shape == (B, T)
+
+    # With average_grid=True, sum_vars=False -> (B, T, d_state)
+    result = metric_func(
+        pred, target, pred_std, sum_vars=False, grid_weights=weights
+    )
+    assert result.shape == (B, T, d_state)
+
+    # With average_grid=False, sum_vars=True -> (B, T, N)
+    result = metric_func(
+        pred, target, pred_std, average_grid=False, grid_weights=weights
+    )
+    assert result.shape == (B, T, N)
+
+    # With average_grid=False, sum_vars=False -> (B, T, N, d_state)
+    result = metric_func(
+        pred,
+        target,
+        pred_std,
+        average_grid=False,
+        sum_vars=False,
+        grid_weights=weights,
+    )
+    assert result.shape == (B, T, N, d_state)
+
+
+# ============================================================
+# Test: mask + weights combined for each metric
+# ============================================================
+@pytest.mark.parametrize("metric_name", metrics.DEFINED_METRICS.keys())
+def test_metrics_with_mask_and_weights(
+    metric_name, dummy_data, non_uniform_weights, mask
+):
+    """
+    Verify that mask and grid_weights can be used together without errors
+    and produce valid output.
+    """
+    pred, target, pred_std = dummy_data
+    metric_func = metrics.get_metric(metric_name)
+
+    result = metric_func(
+        pred,
+        target,
+        pred_std,
+        mask=mask,
+        grid_weights=non_uniform_weights,
+    )
+
+    assert not torch.isnan(result).any()
+    assert not torch.isinf(result).any()
+    assert result.shape == (2,)  # (B,) after reducing grid and vars
+
+
+# ============================================================
+# Test: edge case — single grid point
+# ============================================================
+@pytest.mark.parametrize("metric_name", metrics.DEFINED_METRICS.keys())
+def test_single_grid_point(metric_name):
+    """
+    Metrics should work with a single grid point and grid_weights.
+    """
+    pred = torch.randn(1, 1, 2)
+    target = torch.randn(1, 1, 2)
+    pred_std = torch.abs(torch.randn(1, 1, 2)) + 0.1
+    weights = torch.tensor([1.0])
+
+    metric_func = metrics.get_metric(metric_name)
+    result = metric_func(pred, target, pred_std, grid_weights=weights)
+
+    assert not torch.isnan(result).any()
+    assert result.shape == (1,)
+
+
+# ============================================================
+# Test: MSE weighted correctness (manual calculation)
+# ============================================================
+def test_mse_weighted_manual_calculation():
+    """
+    Verify MSE with area weights matches a manual weighted-mean calculation.
+    """
+    # 1 batch, 3 grid points, 1 feature
+    pred = torch.tensor([[[1.0], [2.0], [3.0]]])
+    target = torch.tensor([[[2.0], [2.0], [1.0]]])
+    pred_std = torch.ones(1, 3, 1)
+
+    # Errors: (1-2)^2=1, (2-2)^2=0, (3-1)^2=4
+    # Unweighted mean: (1+0+4)/3 = 5/3
+    result_unweighted = metrics.mse(pred, target, pred_std)
+    expected_unweighted = torch.tensor([5.0 / 3.0])
+    torch.testing.assert_close(
+        result_unweighted, expected_unweighted, atol=1e-6, rtol=1e-6
+    )
+
+    # Weighted: w=[1,2,1], normalized: [1/4, 2/4, 1/4]
+    # Weighted mean: (1*1/4 + 0*2/4 + 4*1/4) = 5/4 = 1.25
+    weights = torch.tensor([1.0, 2.0, 1.0])
+    result_weighted = metrics.mse(pred, target, pred_std, grid_weights=weights)
+    expected_weighted = torch.tensor([5.0 / 4.0])
+    torch.testing.assert_close(
+        result_weighted, expected_weighted, atol=1e-6, rtol=1e-6
+    )
+
+
+# ============================================================
+# Test: MAE weighted correctness (manual calculation)
+# ============================================================
+def test_mae_weighted_manual_calculation():
+    """
+    Verify MAE with area weights matches a manual weighted-mean calculation.
+    """
+    # 1 batch, 3 grid points, 1 feature
+    pred = torch.tensor([[[1.0], [3.0], [5.0]]])
+    target = torch.tensor([[[2.0], [3.0], [2.0]]])
+    pred_std = torch.ones(1, 3, 1)
+
+    # Errors: |1-2|=1, |3-3|=0, |5-2|=3
+    # Weighted: w=[3,1,2], normalized: [3/6, 1/6, 2/6] = [0.5, 1/6, 1/3]
+    # Weighted mean: 1*0.5 + 0*1/6 + 3*1/3 = 0.5 + 0 + 1 = 1.5
+    weights = torch.tensor([3.0, 1.0, 2.0])
+    result_weighted = metrics.mae(pred, target, pred_std, grid_weights=weights)
+    expected_weighted = torch.tensor([1.5])
+    torch.testing.assert_close(
+        result_weighted, expected_weighted, atol=1e-6, rtol=1e-6
+    )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -52,45 +52,29 @@ def mask():
 
 
 # ============================================================
-# Test: backward compatibility (grid_weights=None)
+# Test: backward compatibility — None and uniform weights
+# both give the same result as no-weights call
 # ============================================================
 @pytest.mark.parametrize("metric_name", metrics.DEFINED_METRICS.keys())
-def test_no_weights_gives_same_result_as_before(metric_name, dummy_data):
+def test_no_or_uniform_weights_gives_same_result(
+    metric_name, dummy_data, uniform_weights
+):
     """
-    When grid_weights=None (default), all metrics should produce the same
-    result as the original unweighted implementation.
+    When grid_weights is None (default) or uniform (all ones), every metric
+    should produce the same result as the original unweighted call.
     """
     pred, target, pred_std = dummy_data
     metric_func = metrics.get_metric(metric_name)
 
     result_no_kwarg = metric_func(pred, target, pred_std)
     result_none = metric_func(pred, target, pred_std, grid_weights=None)
-
-    torch.testing.assert_close(result_no_kwarg, result_none)
-
-
-# ============================================================
-# Test: uniform weights == no weights
-# ============================================================
-@pytest.mark.parametrize("metric_name", metrics.DEFINED_METRICS.keys())
-def test_uniform_weights_equals_no_weights(
-    metric_name, dummy_data, uniform_weights
-):
-    """
-    Uniform weights (all ones) should produce the same result as no weights,
-    since the weighted mean with equal weights is the same as the arithmetic
-    mean.
-    """
-    pred, target, pred_std = dummy_data
-    metric_func = metrics.get_metric(metric_name)
-
-    result_no_weights = metric_func(pred, target, pred_std)
     result_uniform = metric_func(
         pred, target, pred_std, grid_weights=uniform_weights
     )
 
+    torch.testing.assert_close(result_no_kwarg, result_none)
     torch.testing.assert_close(
-        result_no_weights, result_uniform, atol=1e-5, rtol=1e-5
+        result_no_kwarg, result_uniform, atol=1e-5, rtol=1e-5
     )
 
 
@@ -249,35 +233,21 @@ class TestMaskAndReduceMetric:
 class TestComputeAreaWeights:
     """Tests for the compute_area_weights utility function."""
 
-    def test_weights_shape(self):
-        """Weights should have shape (N,) matching grid points."""
-        datastore = DummyDatastore()
-        weights = metrics.compute_area_weights(datastore)
-        assert weights.shape == (datastore.num_grid_points,)
-
-    def test_weights_positive(self):
-        """All area weights should be positive."""
-        datastore = DummyDatastore()
-        weights = metrics.compute_area_weights(datastore)
-        assert (weights > 0).all()
-
-    def test_weights_sum_to_n(self):
-        """Weights should be normalized to sum to N (mean = 1)."""
+    def test_weights_properties(self):
+        """Weights shape, dtype, positivity, and normalization."""
         datastore = DummyDatastore()
         weights = metrics.compute_area_weights(datastore)
         n = datastore.num_grid_points
+
+        assert weights.shape == (n,)
+        assert weights.dtype == torch.float32
+        assert (weights > 0).all()
         torch.testing.assert_close(
             weights.sum(),
             torch.tensor(float(n)),
             atol=1e-4,
             rtol=1e-4,
         )
-
-    def test_weights_dtype(self):
-        """Weights should be float32."""
-        datastore = DummyDatastore()
-        weights = metrics.compute_area_weights(datastore)
-        assert weights.dtype == torch.float32
 
 
 # ============================================================


### PR DESCRIPTION

Implemented area weights for grid-point averaging in the metrics module to ensure spatially weighted averaging instead of uniform averaging. Updated the related metric computations accordingly and added corresponding unit tests to validate correctness.

This improves the physical correctness of spatial averaging, especially for latitude-longitude grids where grid cells represent unequal surface areas.

No additional external dependencies were introduced.

## Issue Link
#212 – mask_and_reduce_metric does not support area-weighted averaging over grid points

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] I have given the PR a clear name

