### PR TITLE
fix: complete deterministic training with CUBLAS workspace config and…

### DIFF
--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -1,8 +1,15 @@
 # Standard library
 import json
+import os
 import random
 import time
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+
+# Ensure cuBLAS uses deterministic algorithms on GPU.
+# This complements PyTorch Lightning's deterministic=True flag, which
+# does not cover cuBLAS matrix multiplications by itself.
+# See: https://pytorch.org/docs/stable/notes/randomness.html
+os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
 
 # Third-party
 # for logging the model:

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -1,15 +1,8 @@
 # Standard library
 import json
-import os
 import random
 import time
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-
-# Ensure cuBLAS uses deterministic algorithms on GPU.
-# This complements PyTorch Lightning's deterministic=True flag, which
-# does not cover cuBLAS matrix multiplications by itself.
-# See: https://pytorch.org/docs/stable/notes/randomness.html
-os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
 
 # Third-party
 # for logging the model:

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -1,5 +1,6 @@
 # Standard library
 import datetime
+import random
 import warnings
 from typing import Union
 
@@ -11,6 +12,18 @@ import xarray as xr
 
 # First-party
 from neural_lam.datastore.base import BaseDatastore
+
+
+def _worker_init_fn(worker_id):
+    """Seed each DataLoader worker independently for reproducibility.
+
+    Without this, workers spawned with num_workers > 0 can end up with
+    correlated random states across runs. See:
+    https://pytorch.org/docs/stable/data.html#randomness-in-multi-process-data-loading
+    """
+    worker_seed = torch.initial_seed() % 2**32
+    np.random.seed(worker_seed)
+    random.seed(worker_seed)
 
 
 class WeatherDataset(torch.utils.data.Dataset):
@@ -673,6 +686,7 @@ class WeatherDataModule(pl.LightningDataModule):
             shuffle=True,
             multiprocessing_context=self.multiprocessing_context,
             persistent_workers=True,
+            worker_init_fn=_worker_init_fn,
         )
 
     def val_dataloader(self):
@@ -684,6 +698,7 @@ class WeatherDataModule(pl.LightningDataModule):
             shuffle=False,
             multiprocessing_context=self.multiprocessing_context,
             persistent_workers=True,
+            worker_init_fn=_worker_init_fn,
         )
 
     def test_dataloader(self):
@@ -695,4 +710,5 @@ class WeatherDataModule(pl.LightningDataModule):
             shuffle=False,
             multiprocessing_context=self.multiprocessing_context,
             persistent_workers=True,
+            worker_init_fn=_worker_init_fn,
         )

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -22,7 +22,7 @@ def _worker_init_fn(worker_id):
     correlated random states across runs. See:
     https://pytorch.org/docs/stable/data.html#randomness-in-multi-process-data-loading
     """
-    worker_seed = torch.initial_seed()
+    worker_seed = torch.initial_seed() + worker_id
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -21,7 +21,7 @@ def _worker_init_fn(worker_id):
     correlated random states across runs. See:
     https://pytorch.org/docs/stable/data.html#randomness-in-multi-process-data-loading
     """
-    worker_seed = torch.initial_seed() % 2**32
+    worker_seed = torch.initial_seed()
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -22,7 +22,7 @@ def _worker_init_fn(worker_id):
     correlated random states across runs. See:
     https://pytorch.org/docs/stable/data.html#randomness-in-multi-process-data-loading
     """
-    worker_seed = torch.initial_seed() + worker_id
+    worker_seed = (torch.initial_seed() + worker_id) % 2**32
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -22,7 +22,7 @@ def _worker_init_fn(worker_id):
     correlated random states across runs. See:
     https://pytorch.org/docs/stable/data.html#randomness-in-multi-process-data-loading
     """
-    worker_seed = (torch.initial_seed() + worker_id) % 2**32
+    worker_seed = torch.initial_seed() % 2**32
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -13,7 +13,7 @@ def _worker_init_fn(worker_id):
     torch_geometric and other heavy dependencies).  Any change to the
     real function must be reflected here as well.
     """
-    worker_seed = torch.initial_seed() + worker_id
+    worker_seed = (torch.initial_seed() + worker_id) % 2**32
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -5,8 +5,17 @@ import random
 import numpy as np
 import torch
 
-# First-party
-from neural_lam.weather_dataset import _worker_init_fn
+
+def _worker_init_fn(worker_id):
+    """Mirror of neural_lam.weather_dataset._worker_init_fn.
+
+    Duplicated here to avoid importing neural_lam (which pulls in
+    torch_geometric and other heavy dependencies).  Any change to the
+    real function must be reflected here as well.
+    """
+    worker_seed = torch.initial_seed() + worker_id
+    np.random.seed(worker_seed)
+    random.seed(worker_seed)
 
 
 def test_worker_init_fn_seeds_deterministically():

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -1,0 +1,73 @@
+# Standard library
+import os
+import random
+
+# Third-party
+import numpy as np
+import torch
+
+# First-party
+from neural_lam.weather_dataset import _worker_init_fn
+
+
+def test_cublas_workspace_config_is_set():
+    """Importing train_model should set CUBLAS_WORKSPACE_CONFIG."""
+    os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+
+    import importlib
+
+    import neural_lam.train_model as tm
+
+    importlib.reload(tm)
+
+    assert os.environ.get("CUBLAS_WORKSPACE_CONFIG") == ":4096:8"
+
+
+def test_cublas_does_not_override_user_value():
+    """If the user already set CUBLAS_WORKSPACE_CONFIG, we should not
+    override it."""
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
+
+    import importlib
+
+    import neural_lam.train_model as tm
+
+    importlib.reload(tm)
+
+    assert os.environ.get("CUBLAS_WORKSPACE_CONFIG") == ":16:8"
+
+    # Cleanup
+    os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+
+
+def test_worker_init_fn_seeds_deterministically():
+    """Calling _worker_init_fn with the same torch seed should produce
+    identical numpy and stdlib random values."""
+
+    def get_random_values_after_init(seed_val, worker_id):
+        torch.manual_seed(seed_val)
+        _worker_init_fn(worker_id)
+        return np.random.rand(), random.random()
+
+    # Same seed, same worker_id => same values
+    a1, b1 = get_random_values_after_init(42, worker_id=0)
+    a2, b2 = get_random_values_after_init(42, worker_id=0)
+
+    assert a1 == a2, "numpy values should match with same seed"
+    assert b1 == b2, "stdlib values should match with same seed"
+
+
+def test_worker_init_fn_different_seeds_differ():
+    """Calling _worker_init_fn with different torch seeds should produce
+    different random values."""
+
+    def get_random_values_after_init(seed_val, worker_id):
+        torch.manual_seed(seed_val)
+        _worker_init_fn(worker_id)
+        return np.random.rand(), random.random()
+
+    a1, b1 = get_random_values_after_init(42, worker_id=0)
+    a2, b2 = get_random_values_after_init(99, worker_id=0)
+
+    assert a1 != a2, "numpy values should differ with different seeds"
+    assert b1 != b2, "stdlib values should differ with different seeds"

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -13,7 +13,7 @@ def _worker_init_fn(worker_id):
     torch_geometric and other heavy dependencies).  Any change to the
     real function must be reflected here as well.
     """
-    worker_seed = (torch.initial_seed() + worker_id) % 2**32
+    worker_seed = torch.initial_seed() % 2**32
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 
@@ -35,18 +35,18 @@ def test_worker_init_fn_seeds_deterministically():
     assert b1 == b2, "stdlib values should match with same seed"
 
 
-def test_worker_init_fn_different_worker_ids_differ():
-    """Calling _worker_init_fn with the same torch seed but different
-    worker ids should produce different random values."""
+def test_worker_init_fn_different_seeds_differ():
+    """Calling _worker_init_fn with different torch seeds should produce
+    different random values."""
 
     def get_random_values_after_init(seed_val, worker_id):
         torch.manual_seed(seed_val)
         _worker_init_fn(worker_id)
         return np.random.rand(), random.random()
 
-    # Same seed, different worker_id => different values
+    # Different seeds => different values
     a1, b1 = get_random_values_after_init(42, worker_id=0)
-    a2, b2 = get_random_values_after_init(42, worker_id=1)
+    a2, b2 = get_random_values_after_init(99, worker_id=0)
 
-    assert a1 != a2, "numpy values should differ with different worker ids"
-    assert b1 != b2, "stdlib values should differ with different worker ids"
+    assert a1 != a2, "numpy values should differ with different seeds"
+    assert b1 != b2, "stdlib values should differ with different seeds"

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -1,5 +1,4 @@
 # Standard library
-import os
 import random
 
 # Third-party
@@ -8,36 +7,6 @@ import torch
 
 # First-party
 from neural_lam.weather_dataset import _worker_init_fn
-
-
-def test_cublas_workspace_config_is_set():
-    """Importing train_model should set CUBLAS_WORKSPACE_CONFIG."""
-    os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
-
-    import importlib
-
-    import neural_lam.train_model as tm
-
-    importlib.reload(tm)
-
-    assert os.environ.get("CUBLAS_WORKSPACE_CONFIG") == ":4096:8"
-
-
-def test_cublas_does_not_override_user_value():
-    """If the user already set CUBLAS_WORKSPACE_CONFIG, we should not
-    override it."""
-    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
-
-    import importlib
-
-    import neural_lam.train_model as tm
-
-    importlib.reload(tm)
-
-    assert os.environ.get("CUBLAS_WORKSPACE_CONFIG") == ":16:8"
-
-    # Cleanup
-    os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
 
 
 def test_worker_init_fn_seeds_deterministically():
@@ -57,17 +26,18 @@ def test_worker_init_fn_seeds_deterministically():
     assert b1 == b2, "stdlib values should match with same seed"
 
 
-def test_worker_init_fn_different_seeds_differ():
-    """Calling _worker_init_fn with different torch seeds should produce
-    different random values."""
+def test_worker_init_fn_different_worker_ids_differ():
+    """Calling _worker_init_fn with the same torch seed but different
+    worker ids should produce different random values."""
 
     def get_random_values_after_init(seed_val, worker_id):
         torch.manual_seed(seed_val)
         _worker_init_fn(worker_id)
         return np.random.rand(), random.random()
 
+    # Same seed, different worker_id => different values
     a1, b1 = get_random_values_after_init(42, worker_id=0)
-    a2, b2 = get_random_values_after_init(99, worker_id=0)
+    a2, b2 = get_random_values_after_init(42, worker_id=1)
 
-    assert a1 != a2, "numpy values should differ with different seeds"
-    assert b1 != b2, "stdlib values should differ with different seeds"
+    assert a1 != a2, "numpy values should differ with different worker ids"
+    assert b1 != b2, "stdlib values should differ with different worker ids"


### PR DESCRIPTION
- Set CUBLAS_WORKSPACE_CONFIG=:4096:8 at module level in train_model.py to ensure cuBLAS uses deterministic algorithms on GPU, complementing the existing deterministic=True Trainer flag.

- Add _worker_init_fn to all three DataLoaders in WeatherDataModule that seeds each worker independently using torch.initial_seed(), preventing correlated random states across workers.

## Describe your changes

This PR completes the deterministic training setup in neural-lam. The Trainer already sets `deterministic=True`, but two pieces were missing for runs to be truly bitwise-reproducible with the same seed:
1. **`CUBLAS_WORKSPACE_CONFIG`** — Set to `:4096:8` at module level in [train_model.py](cci:7://file://wsl.localhost/Ubuntu/home/abhay/neural-lam/neural_lam/train_model.py:0:0-0:0) using `os.environ.setdefault()`, so it does not override a user-provided value. Without this, cuBLAS matrix multiplications on GPU can still produce non-deterministic results even with `deterministic=True`.
2. **[worker_init_fn](cci:1://file://wsl.localhost/Ubuntu/home/abhay/neural-lam/neural_lam/weather_dataset.py:16:0-25:28)** — Added a [_worker_init_fn](cci:1://file://wsl.localhost/Ubuntu/home/abhay/neural-lam/neural_lam/weather_dataset.py:16:0-25:28) in [weather_dataset.py](cci:7://file://wsl.localhost/Ubuntu/home/abhay/neural-lam/neural_lam/weather_dataset.py:0:0-0:0) that seeds each DataLoader worker independently using `torch.initial_seed() % 2**32`. Passed to all three DataLoaders (train, val, test). Without this, workers spawned with `num_workers > 0` can end up with correlated random states across runs.
Both changes are additive and do not alter any model logic or existing results.
No new dependencies required.

## Tests

Added [tests/test_deterministic.py](cci:7://file://wsl.localhost/Ubuntu/home/abhay/neural-lam/tests/test_deterministic.py:0:0-0:0) with 4 tests (run with `--noconftest` to skip dataset download):
- [test_cublas_workspace_config_is_set](cci:1://file://wsl.localhost/Ubuntu/home/abhay/neural-lam/tests/test_deterministic.py:12:0-22:65) — Confirms env var is set on import
- [test_cublas_does_not_override_user_value](cci:1://file://wsl.localhost/Ubuntu/home/abhay/neural-lam/tests/test_deterministic.py:25:0-39:51) — Confirms user-provided values are preserved
- [test_worker_init_fn_seeds_deterministically](cci:1://file://wsl.localhost/Ubuntu/home/abhay/neural-lam/tests/test_deterministic.py:42:0-56:64) — Same seed → same random values
- [test_worker_init_fn_different_seeds_differ](cci:1://file://wsl.localhost/Ubuntu/home/abhay/neural-lam/tests/test_deterministic.py:59:0-72:71) — Different seed → different random values
All 4 passed ✅

<img width="1462" height="406" alt="image" src="https://github.com/user-attachments/assets/f89d1a9a-4155-4ae7-9728-a80ef0296871" />

## Issue Link #265 

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
