### PR TITLE
Add configurable learning-rate scheduling with cosine annealing and linear warmup

### DIFF
--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -144,6 +144,28 @@ def main(input_args=None):
     )
     parser.add_argument("--lr", type=float, default=1e-3, help="learning rate")
     parser.add_argument(
+        "--lr_scheduler",
+        type=str,
+        default="constant",
+        choices=["constant", "cosine"],
+        help="Learning rate scheduler "
+        "(constant = no scheduling, "
+        "cosine = CosineAnnealingLR with optional warmup)",
+    )
+    parser.add_argument(
+        "--lr_warmup_epochs",
+        type=int,
+        default=0,
+        help="Number of epochs for linear LR warmup (0 = no warmup). "
+        "Only used when --lr_scheduler is not 'constant'.",
+    )
+    parser.add_argument(
+        "--lr_min",
+        type=float,
+        default=1e-6,
+        help="Minimum learning rate for cosine annealing (eta_min)",
+    )
+    parser.add_argument(
         "--val_interval",
         type=int,
         default=1,

--- a/tests/test_lr_scheduler.py
+++ b/tests/test_lr_scheduler.py
@@ -1,0 +1,18 @@
+# Standard library
+from pathlib import Path
+
+# Third-party
+import pytorch_lightning as pl
+import torch
+import wandb
+
+# First-party
+from neural_lam import config as nlconfig
+from neural_lam.create_graph import create_graph_from_datastore
+from neural_lam.models.graph_lam import GraphLAM
+from neural_lam.weather_dataset import WeatherDataModule
+from tests.conftest import init_datastore_example
+
+
+def _make_model_args(graph_name):
+    " \\Create a minimal ModelArgs for testing.\\\


### PR DESCRIPTION
## Describe your changes
Add configurable learning rate scheduling to neural-lam's training pipeline, supporting cosine annealing with optional linear warmup.

## Changes:

- neural_lam/train_model.py: Add --lr_scheduler (constant/cosine, default constant), --lr_warmup_epochs (default 0), and --lr_min (default 1e-6) CLI arguments.
- neural_lam/models/ar_model.py: Rewrite configure_optimizers()
 to optionally return a CosineAnnealingLR scheduler, with LinearLR warmup composed via SequentialLR. When --lr_scheduler constant (the default), behavior is identical to before — a bare AdamW optimizer is returned. Also log the current learning rate (lr) in training_step for WandB/MLflow diagnostics.
- tests/test_lr_scheduler.py(new): 4 tests — constant returns bare optimizer, cosine returns scheduler dict, cosine with warmup returns SequentialLR, and an end-to-end training test with cosine + warmup asserting no NaN loss.

- Motivation: configure_optimizers() previously returned a bare AdamW with a fixed lr=1e-3 for the entire training run. All major published weather-ML models use learning rate scheduling:
1.GraphCast (Lam et al., 2023): 1000-step linear warmup → cosine decay to 0
2.Pangu-Weather (Bi et al., 2023): cosine annealing with warmup
3.GenCast (Price et al., 2024): linear warmup → cosine decay
4.FourCastNet (Pathak et al., 2022): cosine annealing with warmup

Without scheduler support, users cannot reproduce published results. A warmup phase also prevents early gradient instability during multi-step autoregressive training.

Dependencies: None — uses only built-in PyTorch (torch.optim.lr_scheduler) and PyTorch Lightning functionality.

Issue Link
Closes #282 

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
