### PR TITLE
fix: save eval predictions to zarr (multi-GPU safe, correct time semantics

### DIFF
--- a/neural_lam/models/module.py
+++ b/neural_lam/models/module.py
@@ -6,9 +6,11 @@ from typing import Any, Dict, List, Optional
 # Third-party
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import pytorch_lightning as pl
 import torch
 import xarray as xr
+from loguru import logger
 from PIL import Image
 
 # First-party
@@ -188,6 +190,9 @@ class ForecasterModule(pl.LightningModule):
         self.n_example_pred = n_example_pred
         self.create_gif = create_gif
         self.plotted_examples = 0
+        self.save_eval_to_zarr_path = getattr(
+            args, "save_eval_to_zarr_path", None
+        )
 
         # For storing spatial loss maps during evaluation
         self.spatial_loss_maps: List[Any] = []
@@ -386,9 +391,89 @@ class ForecasterModule(pl.LightningModule):
         for metric_list in self.val_metrics.values():
             metric_list.clear()
 
+    def _save_predictions_to_zarr(
+        self,
+        batch_times: torch.Tensor,
+        batch_predictions: torch.Tensor,
+        batch_idx: int,
+        zarr_output_path: str,
+    ):
+        """Save one batch of rescaled state predictions to a Zarr dataset."""
+        batch_predictions = batch_predictions.cpu()
+        batch_times_cpu = batch_times.cpu()
+        batch_size = batch_predictions.shape[0]
+
+        step_ns = int(pd.Timedelta(self.datastore.step_length).value)
+        analysis_times_ns = (
+            batch_times_cpu[:, 0].numpy().astype("int64") - step_ns
+        )
+        analysis_times = analysis_times_ns.astype("datetime64[ns]")
+
+        pred_steps = batch_times_cpu.shape[1]
+        offsets_ns = np.arange(1, pred_steps + 1, dtype="int64") * step_ns
+        elapsed = offsets_ns.astype("timedelta64[ns]")
+
+        time_encoding = {
+            "start_time": {
+                "units": "Seconds since 1970-01-01 00:00:00",
+                "dtype": "int64",
+            },
+            "elapsed_forecast_duration": {
+                "units": "seconds",
+                "dtype": "int64",
+            },
+        }
+
+        das = []
+        for i in range(batch_size):
+            da_i = self._create_dataarray_from_tensor(
+                tensor=batch_predictions[i],
+                time=batch_times_cpu[i],
+                split="test",
+                category="state",
+            )
+            da_i = da_i.assign_coords(
+                elapsed_forecast_duration=("time", elapsed)
+            )
+            da_i = da_i.swap_dims({"time": "elapsed_forecast_duration"})
+            da_i = da_i.drop_vars("time", errors="ignore")
+            da_i.name = "state"
+            das.append(da_i)
+
+        da_batch = xr.concat(das, dim="start_time")
+        da_batch = da_batch.assign_coords(
+            start_time=("start_time", analysis_times)
+        )
+        da_batch = da_batch.chunk({"start_time": batch_size})
+        ds_batch = da_batch.to_dataset(name="state")
+
+        if self.trainer.is_global_zero and batch_idx == 0:
+            logger.info(f"Creating Zarr store at {zarr_output_path}")
+            state_da = self.datastore.get_dataarray(
+                category="state", split="test"
+            )
+            assert state_da is not None
+            all_times = state_da.coords["time"].values
+            template_da = da_batch.reindex(
+                start_time=all_times, fill_value=np.nan
+            )
+            template_ds = template_da.to_dataset(name="state")
+            template_ds.to_zarr(
+                zarr_output_path,
+                compute=False,
+                mode="w",
+                encoding=time_encoding,
+                consolidated=True,
+            )
+
+        self.trainer.strategy.barrier()
+        ds_batch.to_zarr(zarr_output_path, region="auto")
+
     # pylint: disable-next=unused-argument
     def test_step(self, batch, batch_idx):
-        prediction, target_states, pred_std, _ = self.common_step(batch)
+        prediction, target_states, pred_std, batch_times = self.common_step(
+            batch
+        )
 
         if pred_std is not None:
             mean_pred_std = torch.mean(
@@ -449,6 +534,15 @@ class ForecasterModule(pl.LightningModule):
             ],
         ]
         self.spatial_loss_maps.append(log_spatial_losses)
+
+        if self.save_eval_to_zarr_path:
+            prediction_rescaled = prediction * self.state_std + self.state_mean
+            self._save_predictions_to_zarr(
+                batch_times=batch_times,
+                batch_predictions=prediction_rescaled,
+                batch_idx=batch_idx,
+                zarr_output_path=self.save_eval_to_zarr_path,
+            )
 
         if (
             self.trainer.is_global_zero

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -261,6 +261,14 @@ def main(input_args=None):
         help="If set, create GIF animations from prediction PNG frames and "
         "save to disk. PNGs are always created and logged to wandb/mlflow.",
     )
+    eval_group.add_argument(
+        "--save-eval-to-zarr-path",
+        type=str,
+        default=None,
+        dest="save_eval_to_zarr_path",
+        help="If set, save evaluation predictions in original data scale "
+        "to a Zarr store at this path.",
+    )
 
     # Logger Settings
     logger_group = parser.add_argument_group("Logger Settings")

--- a/tests/test_zarr_eval.py
+++ b/tests/test_zarr_eval.py
@@ -1,0 +1,149 @@
+# Standard library
+from pathlib import Path
+
+# Third-party
+import numpy as np
+import pytorch_lightning as pl
+import torch
+import xarray as xr
+
+# First-party
+from neural_lam import config as nlconfig
+from neural_lam.create_graph import create_graph_from_datastore
+from neural_lam.models import ARForecaster, ForecasterModule, GraphLAM
+from neural_lam.weather_dataset import WeatherDataModule
+from tests.conftest import init_datastore_example
+
+
+class ModelArgs:
+    """Minimal args object for testing zarr eval saving."""
+
+    output_std = False
+    loss = "mse"
+    restore_opt = False
+    n_example_pred = 0  # skip plotting to keep the test fast
+    graph = "1level"
+    hidden_dim = 4
+    hidden_layers = 1
+    processor_layers = 2
+    mesh_aggr = "sum"
+    lr = 1.0e-3
+    val_steps_to_log = [1, 2]
+    metrics_watch: list[str] = []
+    num_past_forcing_steps = 1
+    num_future_forcing_steps = 1
+    save_eval_to_zarr_path = None  # overridden per test
+
+
+def run_zarr_eval(datastore, zarr_path):
+    """
+    Run one test epoch using the given datastore and save predictions to
+    *zarr_path*. Returns the opened ``xr.Dataset``.
+    """
+    device_name = "cuda" if torch.cuda.is_available() else "cpu"
+
+    trainer = pl.Trainer(
+        max_epochs=1,
+        deterministic=True,
+        accelerator=device_name,
+        devices=1,
+        log_every_n_steps=1,
+        logger=False,
+        enable_checkpointing=False,
+    )
+
+    graph_name = "1level"
+    graph_dir_path = Path(datastore.root_path) / "graph" / graph_name
+    if not graph_dir_path.exists():
+        create_graph_from_datastore(
+            datastore=datastore,
+            output_root_path=str(graph_dir_path),
+            n_max_levels=1,
+        )
+
+    data_module = WeatherDataModule(
+        datastore=datastore,
+        ar_steps_train=3,
+        ar_steps_eval=3,
+        batch_size=2,
+        num_workers=0,
+        num_past_forcing_steps=1,
+        num_future_forcing_steps=1,
+    )
+
+    model_args = ModelArgs()
+    model_args.save_eval_to_zarr_path = str(zarr_path)
+
+    config = nlconfig.NeuralLAMConfig(
+        datastore=nlconfig.DatastoreSelection(
+            kind=datastore.SHORT_NAME, config_path=datastore.root_path
+        )
+    )
+
+    predictor = GraphLAM(
+        datastore=datastore,
+        graph_name=model_args.graph,
+        hidden_dim=model_args.hidden_dim,
+        hidden_layers=model_args.hidden_layers,
+        processor_layers=model_args.processor_layers,
+        mesh_aggr=model_args.mesh_aggr,
+        num_past_forcing_steps=model_args.num_past_forcing_steps,
+        num_future_forcing_steps=model_args.num_future_forcing_steps,
+        output_std=model_args.output_std,
+        output_clamping_lower=config.training.output_clamping.lower,
+        output_clamping_upper=config.training.output_clamping.upper,
+    )
+    forecaster = ARForecaster(predictor, datastore=datastore)
+    model = ForecasterModule(
+        forecaster=forecaster,
+        config=config,
+        datastore=datastore,
+        loss=model_args.loss,
+        lr=model_args.lr,
+        restore_opt=model_args.restore_opt,
+        n_example_pred=model_args.n_example_pred,
+        val_steps_to_log=model_args.val_steps_to_log,
+        metrics_watch=model_args.metrics_watch,
+        args=model_args,
+    )
+    trainer.test(model=model, datamodule=data_module)
+
+    return xr.open_zarr(str(zarr_path))
+
+
+def test_zarr_eval_single_gpu(tmp_path):
+    """
+    Single-GPU integration test: run eval on DummyDatastore and assert that
+    the Zarr output has the expected structure and correct time semantics.
+    """
+    datastore = init_datastore_example("dummydata")
+    zarr_path = tmp_path / "eval_preds.zarr"
+
+    ds = run_zarr_eval(datastore, zarr_path)
+
+    # 1. Store must exist and contain "state"
+    assert zarr_path.exists(), "Zarr store was not created"
+    assert "state" in ds.data_vars
+
+    # 2. Required dimensions
+    required_dims = {"start_time", "elapsed_forecast_duration"}
+    missing = required_dims - set(ds.dims)
+    assert not missing, f"Missing dimensions: {missing}"
+
+    # 3. Raw 'time' coord must be absent
+    assert "time" not in ds.coords
+
+    # 4. start_time must be analysis_time (= first forecast time - step_length)
+    step_ns = int(
+        ds["elapsed_forecast_duration"].values[0] / np.timedelta64(1, "ns")
+    )
+    for t0 in ds["start_time"].values:
+        first_fcst_abs = t0 + ds["elapsed_forecast_duration"].values[0]
+        expected_t0 = first_fcst_abs - np.timedelta64(step_ns, "ns")
+        assert t0 == expected_t0, f"start_time {t0} != expected {expected_t0}"
+
+    # 5. Values must be finite (confirms rescaling happened)
+    state_sample = float(
+        ds["state"].isel(start_time=0, elapsed_forecast_duration=0).mean()
+    )
+    assert np.isfinite(state_sample), "Zarr output contains NaN/Inf"


### PR DESCRIPTION
## Describe your changes

This PR implements saving evaluation predictions to a Zarr store (original data scale) and addresses the reviewer feedback from the original PR #104.

Key changes:
- Multi-GPU safe: rank-0 writes the Zarr metadata template (`compute=False`), then `barrier()`, then all ranks write their slices via `region="auto"`.
- Correct `start_time`: `analysis_time = batch_times[:, 0] - step_length` (since predictions start at `analysis_time + step_length`).
- Rescale predictions to original scale in `test_step` before writing.
- Drop raw `time` coord after `swap_dims`; explicit `int64` encoding for time variables to avoid round-trip/mixed-unit issues.
- Cache `WeatherDataset` per `(split, category)` to avoid O(N*T) re-instantiation during saving/plotting.
- Add `--save-eval-to-zarr-path` CLI flag.
- Add `tests/test_zarr_eval.py` single-GPU integration test.

Motivation / context:
- This completes the “write eval predictions to zarr” feature discussed in PR #104 and requested in the #138 tracking issue, with correct time semantics and safe distributed writes.

Dependencies:
- No new external dependencies added. Uses existing xarray/zarr stack; relies on xarray Zarr region writes (`region="auto"`).

## Issue Link

Refs #104  
Related to #138

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.