### PR TITLE
Consolidate training run outputs into a single runs/<run-name>/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 ### Project Specific ###
-wandb
-saved_models
-lightning_logs
+runs/
+lightning_logs/
 data
 graphs
 *.sif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased](https://github.com/mllam/neural-lam/compare/v0.5.0...HEAD)
 
+### Changed
+
+- Consolidate all training run output (checkpoints, logs) under a single `runs/<run-name>/` directory instead of scattering across `saved_models/`, `lightning_logs/`, `wandb/` and `mlruns/` [\#293](https://github.com/mllam/neural-lam/issues/293) @PrakshaaleJain
+
 ### Fixed
 
 - Fix README image paths to use absolute GitHub URLs so images display correctly on PyPI [\#188](https://github.com/mllam/neural-lam/pull/188) @bk-simon
-
-- Fix typo in `ar_model.py` that causes `AttributeError` during evaluation [\#204](https://github.com/mllam/neural-lam/pull/204) @ritinikhil
 
 - Changed the hardcoded True to a conditional check "persistent_workers=self.num_workers > 0" [\#235](https://github.com/mllam/neural-lam/pull/235) @santhil-cyber
 
@@ -19,8 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 \#222](https://github.com/mllam/neural-lam/pull/222) @santhil-cyber
 
 - Fix Slack domain link [\#288](https://github.com/mllam/neural-lam/pull/288) @sadamov
-
-- Consolidate all training run output (checkpoints, logs) under a single `runs/<run-name>/` directory instead of scattering across `saved_models/`, `lightning_logs/`, `wandb/` and `mlruns/` [\#293](https://github.com/mllam/neural-lam/issues/293) @PrakshaaleJain
 
 ### Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix Slack domain link [\#288](https://github.com/mllam/neural-lam/pull/288) @sadamov
 
+- Consolidate all training run output (checkpoints, logs) under a single `runs/<run-name>/` directory instead of scattering across `saved_models/`, `lightning_logs/`, `wandb/` and `mlruns/` [\#293](https://github.com/mllam/neural-lam/issues/293) @PrakshaaleJain
+
 ### Maintenance
 
 - Update PR template to clarify milestone/roadmap requirement and maintenance changes [\#186](https://github.com/mllam/neural-lam/pull/186) @joeloskarsson

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ A few of the key ones are outlined below:
 * `--ar_steps_train`: Number of time steps to unroll for when making predictions and computing the loss
 * `--ar_steps_eval`: Number of time steps to unroll for during validation steps
 
-Checkpoints of trained models are stored in the `saved_models` directory.
+Checkpoints of trained models are stored under `runs/<run-name>/checkpoints/`. All run artifacts (checkpoints, logs, eval outputs) are grouped together under `runs/<run-name>/`.
 The implemented models are:
 
 ### Graph-LAM

--- a/neural_lam/custom_loggers.py
+++ b/neural_lam/custom_loggers.py
@@ -15,10 +15,11 @@ class CustomMLFlowLogger(pl.loggers.MLFlowLogger):
     of version `2.0.3` at least.
     """
 
-    def __init__(self, experiment_name, tracking_uri, run_name):
+    def __init__(self, experiment_name, tracking_uri, run_name, save_dir=None):
         super().__init__(
             experiment_name=experiment_name, tracking_uri=tracking_uri
         )
+        self._save_dir = save_dir or "mlruns"
 
         mlflow.start_run(run_id=self.run_id, log_system_metrics=True)
         mlflow.set_tag("mlflow.runName", run_name)
@@ -35,7 +36,7 @@ class CustomMLFlowLogger(pl.loggers.MLFlowLogger):
         str
             Path to the directory where the artifacts are saved.
         """
-        return "mlruns"
+        return self._save_dir
 
     def log_image(self, key, images, step=None):
         """

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -304,11 +304,15 @@ def main(input_args=None):
         )
 
     training_logger = utils.setup_training_logger(
-        datastore=datastore, args=args, run_name=run_name
+        datastore=datastore,
+        args=args,
+        run_name=run_name,
+        run_dir=f"runs/{run_name}",
     )
 
+    run_dir = f"runs/{run_name}"
     checkpoint_callback = pl.callbacks.ModelCheckpoint(
-        dirpath=f"saved_models/{run_name}",
+        dirpath=f"{run_dir}/checkpoints",
         filename="min_val_loss",
         monitor="val_mean_loss",
         mode="min",
@@ -326,6 +330,7 @@ def main(input_args=None):
         callbacks=[checkpoint_callback],
         check_val_every_n_epoch=args.val_interval,
         precision=args.precision,
+        default_root_dir=run_dir,
     )
 
     # Only init once, on rank 0 only

--- a/neural_lam/utils.py
+++ b/neural_lam/utils.py
@@ -330,7 +330,7 @@ def init_training_logger_metrics(training_logger, val_steps):
 
 
 @rank_zero_only
-def setup_training_logger(datastore, args, run_name):
+def setup_training_logger(datastore, args, run_name, run_dir=None):
     """
 
     Parameters
@@ -355,6 +355,7 @@ def setup_training_logger(datastore, args, run_name):
             project=args.logger_project,
             name=run_name,
             config=dict(training=vars(args), datastore=datastore._config),
+            save_dir=run_dir,
         )
     elif args.logger == "mlflow":
         url = os.getenv("MLFLOW_TRACKING_URI")
@@ -366,6 +367,7 @@ def setup_training_logger(datastore, args, run_name):
             experiment_name=args.logger_project,
             tracking_uri=url,
             run_name=run_name,
+            save_dir=run_dir,
         )
         logger.log_hyperparams(
             dict(training=vars(args), datastore=datastore._config)


### PR DESCRIPTION
## Describe your changes

A single training run previously scattered output across five unrelated directories:

| Artifact | Old location |
|---|---|
| Model checkpoints | `saved_models/<run-name>/` |
| Lightning CSV logs | `lightning_logs/version_N/` (auto-incremented, unnamed) |
| W&B offline cache | `wandb/offline-run-<timestamp>-<id>/` |
| Eval artifacts (PDFs, CSVs, `.pt` files) | `wandb/` or `mlruns/` via `self.logger.save_dir` |
| MLFlow artifacts | `mlruns/` (hard-coded in `CustomMLFlowLogger.save_dir`) |

This made it hard to find, archive, or clean up the outputs of a single run.

All output is now grouped under `runs/<run-name>/`:

- **`train_model.py`**: computes `run_dir = f"runs/{run_name}"` and passes it as
  `ModelCheckpoint(dirpath=f"{run_dir}/checkpoints")` and `pl.Trainer(default_root_dir=run_dir)`.
- **`utils.py`**: `setup_training_logger` gains a `run_dir` parameter and passes
  `save_dir=run_dir` to both `WandbLogger` and `CustomMLFlowLogger`.
- **`custom_loggers.py`**: `CustomMLFlowLogger.__init__` accepts `save_dir=None`
  (defaults to `"mlruns"` for backwards compatibility); `save_dir` property returns
  `self._save_dir` instead of a hard-coded string.
- **`.gitignore`**: replaced `saved_models`, `lightning_logs`, `wandb` with a single
  `runs/` entry (kept `lightning_logs/` to ignore test runner output).
- **`README.md`**: updated checkpoint location sentence to reflect the new layout.

No new dependencies required.

## Issue Link

closes #293

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [x] I have updated the [README](README.MD) to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.