### PR TITLE
Fix malformed clamping bounds check and error message

### DIFF
--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -133,9 +133,11 @@ class BaseGraphModel(ARModel):
             if feature in lower_lims and feature in upper_lims:
                 assert (
                     lower_lims[feature] < upper_lims[feature]
-                ), f'Invalid clamping limits for feature "{feature}",\
-                     lower: {lower_lims[feature]}, larger than\
-                     upper: {upper_lims[feature]}'
+                ), (
+                    f'Invalid clamping limits for feature "{feature}", '
+                    f'lower: {lower_lims[feature]}, larger than or equal to '
+                    f'upper: {upper_lims[feature]}'
+                )
                 sigmoid_lower_upper_idx.append(feature_idx)
                 sigmoid_lower_lims.append(
                     normalize_clamping_lim(lower_lims[feature], feature_idx)


### PR DESCRIPTION
## Describe your changes
**Summary of the changes:**
Fixed an assertion error comparison string in `base_graph_model.py` regarding clamping bounds failing due to multi-line string interpolation causing broken tab indentation logging.

**Motivation and context:**
The `base_graph_model.py` bounds clamping exception incorrectly stated properties were "larger than" each other when the assertion actually triggered from bounds equality (`<=`), and outputted visual garbage due to missing text wrappers.

## Issue Link
Splits #255

## Type of change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
