### PR TITLE
Add bounds checking for var_leads_metrics_watch indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Log every figure passed to `CustomMLFlowLogger.log_image` instead of silently dropping all but the first, using per-figure indexed keys (`{key}_{i}`) when more than one is supplied [\#499](https://github.com/mllam/neural-lam/pull/499) @Raj-Taware
 
+- Validate `--var_leads_metrics_watch` variable indices against the datastore in `train_model.py` so an out-of-range index raises a clear CLI error immediately, instead of an `IndexError` deep in the first validation epoch after potentially hours of training [\#306](https://github.com/mllam/neural-lam/pull/306) @Ayushhgit
+
 ### Maintenance
 
 - Add comprehensive type hints to `neural_lam/metrics.py` [\#447](https://github.com/mllam/neural-lam/pull/447) @sidhantpande

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -380,6 +380,19 @@ def main(input_args=None):
     # Load neural-lam configuration and datastore to use
     config, datastore = load_config_and_datastore(config_path=args.config_path)
 
+    # Check --var_leads_metrics_watch variable indices against the datastore
+    # so users get an immediate error instead of an IndexError deep in the
+    # first validation epoch.
+    state_var_names = datastore.get_vars_names(category="state")
+    for var_i in args.var_leads_metrics_watch:
+        if not 0 <= var_i < len(state_var_names):
+            raise ValueError(
+                f"Invalid state variable index {var_i} in "
+                f"--var_leads_metrics_watch. Index must be between 0 and "
+                f"{len(state_var_names) - 1} (datastore has "
+                f"{len(state_var_names)} state variables)."
+            )
+
     # Create datamodule
     data_module = WeatherDataModule(
         datastore=datastore,


### PR DESCRIPTION
## Describe your changes
**Summary of the changes:**
Added a bound check for the `--var_leads_metrics_watch` argument in `train_model.py` to assert that users are asking for variables that physically exist inside the array.

**Motivation and context:**
The `metrics_watch` argument parsing was deferring bounds-checking to heavily inside the validation epoch. Because training massive graphs takes a long time, users passing an invalid JSON argument variable coordinate would train their model for an hour and then hit an IndexError completely destroying the run, rather than failing immediately when the configuration was loaded. 

## Issue Link
Splits #255

## Type of change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
