### PR TITLE
Fix: Add validation to require --load argument during evaluation

### DIFF
--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -225,6 +225,16 @@ def main(input_args=None):
         help="Number of future time steps to use as input for forcing data",
     )
     args = parser.parse_args(input_args)
+    args = parser.parse_args(input_args)
+    
+    # --- INSERT YOUR VALIDATION HERE ---
+    if args.eval and args.load is None:
+        parser.error("In evaluation mode, you must provide a path to a checkpoint using --load.")
+    # -----------------------------------
+
+    args.var_leads_metrics_watch = {
+        int(k): v for k, v in json.loads(args.var_leads_metrics_watch).items()
+    }
     args.var_leads_metrics_watch = {
         int(k): v for k, v in json.loads(args.var_leads_metrics_watch).items()
     }


### PR DESCRIPTION
## Describe your changes

< I have added a validation check to train_model.py to ensure the --load argument is provided when the script is run in evaluation mode (--eval).>

< Previously, if a user ran the evaluation script without providing a checkpoint path, the code would proceed to run and eventually fail with an IndexError. Adding this check provides a clear, user-friendly error message, improving the developer experience. >

< No new dependencies are required for this change.>

## Issue Link

< Closes #105 > (e.g. `closes #00` or `solves #00`)

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist before requesting a review

[x] My branch is up-to-date with the target branch

[x] I have performed a self-review of my code

[x] I have updated the README (N/A - logic remains consistent)

[x] I have given the PR a name that clearly describes the change, written in imperative form

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
