### PR TITLE
Fix/issue 308 create dataarray category feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `WeatherDataset.__len__` off-by-one in analysis mode (was undercounting by 1 sample), include `num_past_forcing_steps` in the forecast-mode minimum-horizon check, validate forcing-side forecast horizon when forcing is present, and use `min(n_state, n_forcing)` when both are present in analysis mode; raise `IndexError` for out-of-range indices in `WeatherDataset.__getitem__` (with Python-style negative indexing support) [\#312](https://github.com/mllam/neural-lam/pull/312) @kshirajahere
 
+- Fix `WeatherDataset.create_dataarray_from_tensor` to look up the feature coordinate dynamically (`{category}_feature`) instead of hardcoded `state_feature` and expose `WeatherDataset.da_static`, so the method works for `state`, `forcing`, and `static` categories without raising `AttributeError` [\#309](https://github.com/mllam/neural-lam/pull/309) @Jayant-kernel
+
 ### Maintenance
 
 - Group the existing Neural-LAM citation papers in the README under a `### Core Neural-LAM Publications` subheading for clearer structure [\#633](https://github.com/mllam/neural-lam/pull/633) @HetaviM29

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -67,6 +67,12 @@ class WeatherDataset(torch.utils.data.Dataset):
         self.da_forcing = self.datastore.get_dataarray(
             category="forcing", split=self.split
         )
+        # Static features are not used during sample construction
+        # (`__getitem__`) but `create_dataarray_from_tensor(category="static")`
+        # needs the static coordinate metadata, so cache it here too.
+        self.da_static = self.datastore.get_dataarray(
+            category="static", split=self.split
+        )
         if self.da_state is None:
             raise ValueError(
                 "The datastore must provide state data for the WeatherDataset."
@@ -589,12 +595,13 @@ class WeatherDataset(torch.utils.data.Dataset):
                 f"{len(tensor.shape)}"
             )
 
-        da_datastore_state = getattr(self, f"da_{category}")
-        da_grid_index = da_datastore_state.grid_index
-        da_state_feature = da_datastore_state.state_feature
+        da_datastore = getattr(self, f"da_{category}")
+        da_grid_index = da_datastore.grid_index
+        feature_coord_name = f"{category}_feature"
+        da_category_feature = da_datastore[feature_coord_name]
 
         coords = {
-            f"{category}_feature": da_state_feature,
+            feature_coord_name: da_category_feature,
             "grid_index": da_grid_index,
         }
         if add_time_as_dim:
@@ -608,10 +615,10 @@ class WeatherDataset(torch.utils.data.Dataset):
 
         for grid_coord in ["x", "y"]:
             if (
-                grid_coord in da_datastore_state.coords
+                grid_coord in da_datastore.coords
                 and grid_coord not in da.coords
             ):
-                da.coords[grid_coord] = da_datastore_state[grid_coord]
+                da.coords[grid_coord] = da_datastore[grid_coord]
 
         if not add_time_as_dim:
             da.coords["time"] = time

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -155,6 +155,34 @@ def test_dataset_item_create_dataarray_from_tensor(datastore_name):
             for coord_name in ["x", "y"]
         )
 
+    # Regression check that create_dataarray_from_tensor works for the
+    # forcing and static categories as well as state (#308).
+    da_forcing_raw = dataset.da_forcing
+    for dim in list(da_forcing_raw.dims):
+        if dim not in ("grid_index", "forcing_feature"):
+            da_forcing_raw = da_forcing_raw.isel({dim: 0})
+    da_forcing_raw = da_forcing_raw.transpose("grid_index", "forcing_feature")
+    da_forcing = dataset.create_dataarray_from_tensor(
+        tensor=torch.tensor(da_forcing_raw.values, dtype=torch.float32),
+        category="forcing",
+        time=target_times[0],
+    )
+    np.testing.assert_equal(
+        da_forcing.forcing_feature.values,
+        da_forcing_raw.forcing_feature.values,
+    )
+
+    da_static_raw = dataset.da_static.transpose("grid_index", "static_feature")
+    da_static = dataset.create_dataarray_from_tensor(
+        tensor=torch.tensor(da_static_raw.values, dtype=torch.float32),
+        category="static",
+        time=target_times[0],
+    )
+    np.testing.assert_equal(
+        da_static.static_feature.values,
+        da_static_raw.static_feature.values,
+    )
+
 
 @pytest.mark.parametrize("split", ["train", "val", "test"])
 @pytest.mark.parametrize("datastore_name", DATASTORES.keys())

--- a/tests/test_time_slicing.py
+++ b/tests/test_time_slicing.py
@@ -50,7 +50,7 @@ class SinglePointDummyDatastore(BaseDatastore):
         elif category == "forcing":
             values = self._forcing_data
         else:
-            raise NotImplementedError(category)
+            return None
 
         if self.is_forecast:
             raise NotImplementedError()


### PR DESCRIPTION
## Describe your changes

Replaced the hardcoded `.state_feature` attribute access in `WeatherDataset.create_dataarray_from_tensor` with a dynamic, category-aware coordinate lookup.

The [create_dataarray_from_tensor](cci:1://file:///c:/Users/jayan/Desktop/Mlaam%20gsoc/neural-lam/neural_lam/weather_dataset.py:509:4-600:17) method accepts a `category` argument (e.g., `"state"`, `"forcing"`, `"static"`), but previously it always accessed `.state_feature` on the underlying datastore DataArray, regardless of the category passed in. This caused an `AttributeError` when the method was called with `category="forcing"` or `category="static"`, because those DataArrays have `forcing_feature` or `static_feature` coordinates instead of [state_feature](cci:1://file:///c:/Users/jayan/Desktop/Mlaam%20gsoc/neural-lam/neural_lam/loss_weighting.py:73:0-105:18).

This fix derives the feature coordinate name dynamically as `f"{category}_feature"` and looks it up via `da_datastore_state[feature_coord_name]`, allowing the method to work correctly for all data categories.

None.

## Issue Link

closes #308

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [x] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
