### PR TITLE
Add unit tests for utils.get_integer_time

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+
+from neural_lam.utils import get_integer_time
+
+
+def test_weeks():
+    assert get_integer_time(timedelta(days=14)) == (2, "weeks")
+
+
+def test_hours():
+    assert get_integer_time(timedelta(hours=5)) == (5, "hours")
+
+
+def test_milliseconds_promotes_to_seconds():
+    assert get_integer_time(timedelta(milliseconds=1000)) == (1, "seconds")
+
+
+def test_docstring_unknown_example():
+    # Matches documented example in utils.py docstring
+    assert get_integer_time(timedelta(days=0.001)) == (1, "unknown")


### PR DESCRIPTION
Adds unit tests for get_integer_time covering documented examples:
- Week conversion
- Hour conversion
- Millisecond promotion to seconds
- Documented `(1, "unknown")` fallback case

Tests align with the existing docstring examples and verify the unit priority order.