### PR TITLE
Add optional grid_weights to mask_and_reduce_metric

### DIFF
--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -40,6 +40,12 @@ def mask_and_reduce_metric(
     metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
     depending on reduction arguments.
     """
+    # Ensure grid_weights matches device and dtype of metric values
+    if grid_weights is not None:
+        grid_weights = grid_weights.to(
+            metric_entry_vals.device, dtype=metric_entry_vals.dtype
+        )
+
     # Only keep grid nodes in mask
     if mask is not None:
         metric_entry_vals = metric_entry_vals[
@@ -53,9 +59,14 @@ def mask_and_reduce_metric(
         if grid_weights is not None:
             # Weighted mean over grid dimension
             w = grid_weights.unsqueeze(-1)  # (N', 1)
+            w_sum = w.sum()
+            if w_sum <= 0:
+                raise ValueError(
+                    "grid_weights must have positive sum after masking"
+                )
             metric_entry_vals = (metric_entry_vals * w).sum(
                 dim=-2
-            ) / w.sum()  # (..., d_state)
+            ) / w_sum  # (..., d_state)
         else:
             metric_entry_vals = torch.mean(
                 metric_entry_vals, dim=-2

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -194,6 +194,38 @@ class TestMaskAndReduceMetric:
         )
         assert result_no_sum.shape == (BATCH, D_STATE)
 
+    def test_zero_weight_sum_raises(self):
+        """Weights that sum to zero after masking should raise ValueError."""
+        # Third-party
+        import pytest
+
+        vals = torch.randn(1, 4, 1)
+        # All weights are on nodes that get masked out
+        weights = torch.tensor([1.0, 0.0, 0.0, 0.0])
+        mask = torch.tensor([False, True, True, True])
+        with pytest.raises(ValueError, match="positive sum"):
+            mask_and_reduce_metric(
+                vals,
+                mask=mask,
+                average_grid=True,
+                sum_vars=False,
+                grid_weights=weights,
+            )
+
+    def test_dtype_casting(self):
+        """Float64 weights with float32 values should work via casting."""
+        vals = torch.randn(BATCH, N_GRID, D_STATE, dtype=torch.float32)
+        weights = torch.ones(N_GRID, dtype=torch.float64)
+        # Should not raise a dtype mismatch error
+        result = mask_and_reduce_metric(
+            vals,
+            mask=None,
+            average_grid=True,
+            sum_vars=False,
+            grid_weights=weights,
+        )
+        assert result.dtype == torch.float32
+
 
 class TestMetricFunctionsWithWeights:
     """Verify all 6 metric functions correctly pass grid_weights through."""


### PR DESCRIPTION

## Describe your changes

Added an optional `grid_weights` parameter to [mask_and_reduce_metric](cci:1://file:///Users/santhil/neural-lam/neural_lam/metrics.py:20:0-52:28)
in [neural_lam/metrics.py](cci:7://file:///Users/santhil/neural-lam/neural_lam/metrics.py:0:0-0:0). When `average_grid=True` and `grid_weights`
is provided, the function computes a weighted mean over the grid
dimension instead of `torch.mean`. Weights are correctly subsetted when
a boolean [mask](cci:1://file:///Users/santhil/neural-lam/neural_lam/models/ar_model.py:206:4-211:54) is also applied.

**Motivation:** For global weather forecasting on regular lat-lon grids,
grid nodes represent different physical areas — a node at the equator
covers ~5× more area than one at 80°N. Without area weighting,
`torch.mean` over-represents polar regions. This is the standard
approach used by WeatherBench2 and operational NWP centres.

All 6 existing metric functions now accept and forward `grid_weights`
as a keyword argument. No existing function signatures are changed —
`grid_weights` defaults to `None`, preserving exact existing behavior.

Added [tests/test_metrics.py](cci:7://file:///Users/santhil/neural-lam/tests/test_metrics.py:0:0-0:0) with 14 tests covering backward
compatibility, weighted mean correctness, cos-latitude weighting,
mask+weights interaction, and all 6 metric functions.

No new dependencies required.

## Issue Link

Refs #313

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
