### PR TITLE
consolidate run outputs into runs/<run-name>/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 ### Project Specific ###
-wandb
-saved_models
-lightning_logs
+runs/
 data
 graphs
 *.sif

--- a/README.md
+++ b/README.md
@@ -405,7 +405,8 @@ The graph-related files are stored in a directory called `graphs`.
 ### Weights & Biases Integration
 The project is fully integrated with [Weights & Biases](https://www.wandb.ai/) (W&B) for logging and visualization, but can just as easily be used without it.
 When W&B is used, training configuration, training/test statistics and plots are sent to the W&B servers and made available in an interactive web interface.
-If W&B is turned off, logging instead saves everything locally to a directory like `wandb/dryrun...`.
+If W&B is turned off, logging instead saves everything locally under `runs/<run-name>/`.
+```
 The W&B project name is set to `neural-lam`, but this can be changed in the flags of `python -m neural_lam.train_model` (using argsparse).
 See the [W&B documentation](https://docs.wandb.ai/) for details.
 
@@ -438,7 +439,8 @@ A few of the key ones are outlined below:
 * `--ar_steps_train`: Number of time steps to unroll for when making predictions and computing the loss
 * `--ar_steps_eval`: Number of time steps to unroll for during validation steps
 
-Checkpoints of trained models are stored in the `saved_models` directory.
+Checkpoints of trained models are stored in the `runs/<run-name>/checkpoints` directory.
+```
 The implemented models are:
 
 ### Graph-LAM
@@ -492,8 +494,8 @@ Using SLURM, the job can be started with `sbatch slurm_job.sh` with a shell scri
 #SBATCH --mem=444G
 #SBATCH --no-requeue
 #SBATCH --exclusive
-#SBATCH --output=lightning_logs/neurallam_out_%j.log
-#SBATCH --error=lightning_logs/neurallam_err_%j.log
+#SBATCH --output=runs/neurallam_out_%j.log
+#SBATCH --error=runs/neurallam_err_%j.log
 
 # Load necessary modules or activate environment, for example:
 conda activate neural-lam

--- a/neural_lam/custom_loggers.py
+++ b/neural_lam/custom_loggers.py
@@ -15,14 +15,14 @@ class CustomMLFlowLogger(pl.loggers.MLFlowLogger):
     of version `2.0.3` at least.
     """
 
-    def __init__(self, experiment_name, tracking_uri, run_name):
+    def __init__(self, experiment_name, tracking_uri, run_name, save_dir="runs"):
         super().__init__(
-            experiment_name=experiment_name, tracking_uri=tracking_uri
-        )
-
+        experiment_name=experiment_name, tracking_uri=tracking_uri
+    )
         mlflow.start_run(run_id=self.run_id, log_system_metrics=True)
         mlflow.set_tag("mlflow.runName", run_name)
         mlflow.log_param("run_id", self.run_id)
+        self._save_dir = save_dir
 
     @property
     def save_dir(self):
@@ -35,7 +35,7 @@ class CustomMLFlowLogger(pl.loggers.MLFlowLogger):
         str
             Path to the directory where the artifacts are saved.
         """
-        return "mlruns"
+        return self._save_dir
 
     def log_image(self, key, images, step=None):
         """

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -308,13 +308,14 @@ def main(input_args=None):
     )
 
     checkpoint_callback = pl.callbacks.ModelCheckpoint(
-        dirpath=f"saved_models/{run_name}",
+        dirpath=f"runs/{run_name}/checkpoints",
         filename="min_val_loss",
         monitor="val_mean_loss",
         mode="min",
         save_last=True,
     )
     trainer = pl.Trainer(
+        default_root_dir=f"runs/{run_name}",
         max_epochs=args.epochs,
         deterministic=True,
         strategy="ddp",

--- a/neural_lam/utils.py
+++ b/neural_lam/utils.py
@@ -354,6 +354,7 @@ def setup_training_logger(datastore, args, run_name):
         logger = pl.loggers.WandbLogger(
             project=args.logger_project,
             name=run_name,
+            save_dir=f"runs/{run_name}",
             config=dict(training=vars(args), datastore=datastore._config),
         )
     elif args.logger == "mlflow":
@@ -366,6 +367,7 @@ def setup_training_logger(datastore, args, run_name):
             experiment_name=args.logger_project,
             tracking_uri=url,
             run_name=run_name,
+            save_dir=f"runs/{run_name}",
         )
         logger.log_hyperparams(
             dict(training=vars(args), datastore=datastore._config)


### PR DESCRIPTION
## Describe your changes
This PR consolidates all training and evaluation outputs into a single
`runs/<run-name>/` directory, instead of being scattered across five
unrelated directories.

Previously a single training run would scatter outputs across:
- Model checkpoints → `saved_models/<run-name>/`
- Lightning CSV logs → `lightning_logs/version_N/`
- W&B offline cache → `wandb/offline-run-<timestamp>/`
- MLFlow artifacts → `mlruns/`

Now everything goes under `runs/<run-name>/`.

No additional dependencies required for this change.

## Issue Link
Closes #293

## Type of change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review
- [x] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have updated the README to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form

## Author checklist after completed review
- [ ] I have added a line to the CHANGELOG describing this change:
  - *changed*: consolidate all training/evaluation run outputs into 
    `runs/<run-name>/` directory instead of scattered directories