### PR TITLE
Fix make metric aggregation use explicit logging semantics (Closes #343)

### DIFF
--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -76,6 +76,14 @@ class BaseMetric:
         """
         return self.name
 
+    @property
+    def __name__(self):
+        """
+        Preserve a function-like name for light introspection/backward
+        compatibility in code that still treats metrics as callables.
+        """
+        return self.name or self.__class__.__name__
+
     def aggregate(self, metric_tensor):
         """
         Aggregate a gathered metric tensor over the evaluation dimension.

--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -2,20 +2,231 @@
 import torch
 
 
-def get_metric(metric_name):
+class BaseMetric:
     """
-    Get a defined metric with given name
+    Base class for all metrics. Each metric is a callable object that also
+    knows how to post-process and rescale its aggregated values for logging.
 
-    metric_name: str, name of the metric
+    This follows the principle that each metric should carry its own logging
+    semantics, rather than relying on hardcoded rules in the aggregation code.
 
-    Returns:
-    metric: function implementing the metric
+    Subclasses must implement `compute_entry_vals` which returns the per-entry
+    metric values before mask-and-reduce.
     """
-    metric_name_lower = metric_name.lower()
-    assert (
-        metric_name_lower in DEFINED_METRICS
-    ), f"Unknown metric: {metric_name}"
-    return DEFINED_METRICS[metric_name_lower]
+
+    # The canonical name of the metric (used for registration/lookup)
+    name: str = ""
+
+    def __call__(
+        self, pred, target, pred_std, mask=None, average_grid=True,
+        sum_vars=True,
+    ):
+        """
+        Compute the metric value.
+
+        (...,) is any number of batch dimensions, potentially different
+            but broadcastable
+        pred: (..., N, d_state), prediction
+        target: (..., N, d_state), target
+        pred_std: (..., N, d_state) or (d_state,), predicted std.-dev.
+        mask: (N,), boolean mask describing which grid nodes to use in metric
+        average_grid: boolean, if grid dimension -2 should be reduced
+            (mean over N)
+        sum_vars: boolean, if variable dimension -1 should be reduced
+            (sum over d_state)
+
+        Returns:
+        metric_val: One of (...,), (..., d_state), (..., N),
+            (..., N, d_state), depending on reduction arguments.
+        """
+        entry_vals = self.compute_entry_vals(
+            pred, target, pred_std
+        )  # (..., N, d_state)
+        return mask_and_reduce_metric(
+            entry_vals, mask=mask, average_grid=average_grid,
+            sum_vars=sum_vars,
+        )
+
+    def compute_entry_vals(self, pred, target, pred_std):
+        """
+        Compute per-entry (per grid node, per variable) metric values
+        before any masking or reduction.
+
+        pred: (..., N, d_state)
+        target: (..., N, d_state)
+        pred_std: (..., N, d_state) or (d_state,)
+
+        Returns: (..., N, d_state) entry-wise metric values
+        """
+        raise NotImplementedError
+
+    @property
+    def display_name(self):
+        """
+        Name to use when logging this metric.
+        Override in subclasses where the logged name differs from the
+        computation name (e.g. MSE is logged as RMSE after sqrt).
+        """
+        return self.name
+
+    def post_process(self, averaged_tensor):
+        """
+        Post-processing applied to the batch-averaged metric tensor
+        before rescaling to physical units.
+
+        Default: identity (no post-processing).
+
+        averaged_tensor: (pred_steps, d_f)
+        Returns: (pred_steps, d_f)
+        """
+        return averaged_tensor
+
+    def rescale(self, tensor, state_std):
+        """
+        Rescale metric tensor from standardized space to physical units.
+
+        Default: linear rescaling by state_std.
+
+        tensor: (pred_steps, d_f)
+        state_std: (d_f,)
+        Returns: (pred_steps, d_f)
+        """
+        return tensor * state_std
+
+
+class MSE(BaseMetric):
+    """
+    (Unweighted) Mean Squared Error.
+    Logged as RMSE (sqrt applied after averaging, then linear rescale).
+    """
+
+    name = "mse"
+
+    def compute_entry_vals(self, pred, target, pred_std):
+        return torch.nn.functional.mse_loss(
+            pred, target, reduction="none"
+        )  # (..., N, d_state)
+
+    @property
+    def display_name(self):
+        return "rmse"
+
+    def post_process(self, averaged_tensor):
+        return torch.sqrt(averaged_tensor)
+
+
+class MAE(BaseMetric):
+    """
+    (Unweighted) Mean Absolute Error.
+    Linear rescaling to physical units.
+    """
+
+    name = "mae"
+
+    def compute_entry_vals(self, pred, target, pred_std):
+        return torch.nn.functional.l1_loss(
+            pred, target, reduction="none"
+        )  # (..., N, d_state)
+
+
+class WMSE(BaseMetric):
+    """
+    Weighted Mean Squared Error (weighted by 1/pred_std^2).
+    Logged as WRMSE (sqrt applied after averaging, then linear rescale).
+    """
+
+    name = "wmse"
+
+    def compute_entry_vals(self, pred, target, pred_std):
+        entry_mse = torch.nn.functional.mse_loss(
+            pred, target, reduction="none"
+        )  # (..., N, d_state)
+        return entry_mse / (pred_std**2)  # (..., N, d_state)
+
+    @property
+    def display_name(self):
+        return "wrmse"
+
+    def post_process(self, averaged_tensor):
+        return torch.sqrt(averaged_tensor)
+
+
+class WMAE(BaseMetric):
+    """
+    Weighted Mean Absolute Error (weighted by 1/pred_std).
+    Linear rescaling to physical units.
+    """
+
+    name = "wmae"
+
+    def compute_entry_vals(self, pred, target, pred_std):
+        entry_mae = torch.nn.functional.l1_loss(
+            pred, target, reduction="none"
+        )  # (..., N, d_state)
+        return entry_mae / pred_std  # (..., N, d_state)
+
+
+class NLL(BaseMetric):
+    """
+    Negative Log Likelihood loss, for isotropic Gaussian likelihood.
+    No rescaling to physical units (NLL is in log-probability space).
+    """
+
+    name = "nll"
+
+    def compute_entry_vals(self, pred, target, pred_std):
+        # Broadcast pred_std if shaped (d_state,),
+        # done internally in Normal class
+        dist = torch.distributions.Normal(
+            pred, pred_std
+        )  # (..., N, d_state)
+        return -dist.log_prob(target)  # (..., N, d_state)
+
+    def rescale(self, tensor, state_std):
+        """NLL values are in log-probability space, not physically
+        rescalable."""
+        return tensor
+
+
+class CRPSGauss(BaseMetric):
+    """
+    (Negative) Continuous Ranked Probability Score (CRPS).
+    Closed-form expression based on Gaussian predictive distribution.
+    Linear rescaling to physical units.
+    """
+
+    name = "crps_gauss"
+
+    def compute_entry_vals(self, pred, target, pred_std):
+        std_normal = torch.distributions.Normal(
+            torch.zeros((), device=pred.device),
+            torch.ones((), device=pred.device),
+        )
+        target_standard = (target - pred) / pred_std  # (..., N, d_state)
+
+        entry_crps = -pred_std * (
+            torch.pi ** (-0.5)
+            - 2 * torch.exp(std_normal.log_prob(target_standard))
+            - target_standard
+            * (2 * std_normal.cdf(target_standard) - 1)
+        )  # (..., N, d_state)
+
+        return entry_crps
+
+
+class OutputStd(BaseMetric):
+    """
+    Predicted standard deviation, treated as a metric for logging.
+    Linear rescaling to physical units.
+
+    Note: This metric is special -- it is not computed from (pred, target)
+    like other metrics, but is instead the spatially-averaged pred_std.
+    Its update logic is handled directly in the model's test_step.
+    The post-processing and rescaling are still handled uniformly through
+    the metric object.
+    """
+
+    name = "output_std"
 
 
 def mask_and_reduce_metric(metric_entry_vals, mask, average_grid, sum_vars):
@@ -53,185 +264,40 @@ def mask_and_reduce_metric(metric_entry_vals, mask, average_grid, sum_vars):
     return metric_entry_vals
 
 
-def wmse(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
-    """
-    Weighted Mean Squared Error
-
-    (...,) is any number of batch dimensions, potentially different
-        but broadcastable
-    pred: (..., N, d_state), prediction
-    target: (..., N, d_state), target
-    pred_std: (..., N, d_state) or (d_state,), predicted std.-dev.
-    mask: (N,), boolean mask describing which grid nodes to use in metric
-    average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
-    sum_vars: boolean, if variable dimension -1 should be reduced (sum
-        over d_state)
-
-    Returns:
-    metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
-    depending on reduction arguments.
-    """
-    entry_mse = torch.nn.functional.mse_loss(
-        pred, target, reduction="none"
-    )  # (..., N, d_state)
-    entry_mse_weighted = entry_mse / (pred_std**2)  # (..., N, d_state)
-
-    return mask_and_reduce_metric(
-        entry_mse_weighted,
-        mask=mask,
-        average_grid=average_grid,
-        sum_vars=sum_vars,
-    )
-
-
-def mse(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
-    """
-    (Unweighted) Mean Squared Error
-
-    (...,) is any number of batch dimensions, potentially different
-        but broadcastable
-    pred: (..., N, d_state), prediction
-    target: (..., N, d_state), target
-    pred_std: (..., N, d_state) or (d_state,), predicted std.-dev.
-    mask: (N,), boolean mask describing which grid nodes to use in metric
-    average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
-    sum_vars: boolean, if variable dimension -1 should be reduced (sum
-        over d_state)
-
-    Returns:
-    metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
-    depending on reduction arguments.
-    """
-    # Replace pred_std with constant ones
-    return wmse(
-        pred, target, torch.ones_like(pred_std), mask, average_grid, sum_vars
-    )
-
-
-def wmae(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
-    """
-    Weighted Mean Absolute Error
-
-    (...,) is any number of batch dimensions, potentially different
-        but broadcastable
-    pred: (..., N, d_state), prediction
-    target: (..., N, d_state), target
-    pred_std: (..., N, d_state) or (d_state,), predicted std.-dev.
-    mask: (N,), boolean mask describing which grid nodes to use in metric
-    average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
-    sum_vars: boolean, if variable dimension -1 should be reduced (sum
-        over d_state)
-
-    Returns:
-    metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
-    depending on reduction arguments.
-    """
-    entry_mae = torch.nn.functional.l1_loss(
-        pred, target, reduction="none"
-    )  # (..., N, d_state)
-    entry_mae_weighted = entry_mae / pred_std  # (..., N, d_state)
-
-    return mask_and_reduce_metric(
-        entry_mae_weighted,
-        mask=mask,
-        average_grid=average_grid,
-        sum_vars=sum_vars,
-    )
-
-
-def mae(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
-    """
-    (Unweighted) Mean Absolute Error
-
-    (...,) is any number of batch dimensions, potentially different
-        but broadcastable
-    pred: (..., N, d_state), prediction
-    target: (..., N, d_state), target
-    pred_std: (..., N, d_state) or (d_state,), predicted std.-dev.
-    mask: (N,), boolean mask describing which grid nodes to use in metric
-    average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
-    sum_vars: boolean, if variable dimension -1 should be reduced (sum
-        over d_state)
-
-    Returns:
-    metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
-    depending on reduction arguments.
-    """
-    # Replace pred_std with constant ones
-    return wmae(
-        pred, target, torch.ones_like(pred_std), mask, average_grid, sum_vars
-    )
-
-
-def nll(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
-    """
-    Negative Log Likelihood loss, for isotropic Gaussian likelihood
-
-    (...,) is any number of batch dimensions, potentially different
-        but broadcastable
-    pred: (..., N, d_state), prediction
-    target: (..., N, d_state), target
-    pred_std: (..., N, d_state) or (d_state,), predicted std.-dev.
-    mask: (N,), boolean mask describing which grid nodes to use in metric
-    average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
-    sum_vars: boolean, if variable dimension -1 should be reduced (sum
-        over d_state)
-
-    Returns:
-    metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
-    depending on reduction arguments.
-    """
-    # Broadcast pred_std if shaped (d_state,), done internally in Normal class
-    dist = torch.distributions.Normal(pred, pred_std)  # (..., N, d_state)
-    entry_nll = -dist.log_prob(target)  # (..., N, d_state)
-
-    return mask_and_reduce_metric(
-        entry_nll, mask=mask, average_grid=average_grid, sum_vars=sum_vars
-    )
-
-
-def crps_gauss(
-    pred, target, pred_std, mask=None, average_grid=True, sum_vars=True
-):
-    """
-    (Negative) Continuous Ranked Probability Score (CRPS)
-    Closed-form expression based on Gaussian predictive distribution
-
-    (...,) is any number of batch dimensions, potentially different
-            but broadcastable
-    pred: (..., N, d_state), prediction
-    target: (..., N, d_state), target
-    pred_std: (..., N, d_state) or (d_state,), predicted std.-dev.
-    mask: (N,), boolean mask describing which grid nodes to use in metric
-    average_grid: boolean, if grid dimension -2 should be reduced (mean over N)
-    sum_vars: boolean, if variable dimension -1 should be reduced (sum
-        over d_state)
-
-    Returns:
-    metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
-    depending on reduction arguments.
-    """
-    std_normal = torch.distributions.Normal(
-        torch.zeros((), device=pred.device), torch.ones((), device=pred.device)
-    )
-    target_standard = (target - pred) / pred_std  # (..., N, d_state)
-
-    entry_crps = -pred_std * (
-        torch.pi ** (-0.5)
-        - 2 * torch.exp(std_normal.log_prob(target_standard))
-        - target_standard * (2 * std_normal.cdf(target_standard) - 1)
-    )  # (..., N, d_state)
-
-    return mask_and_reduce_metric(
-        entry_crps, mask=mask, average_grid=average_grid, sum_vars=sum_vars
-    )
-
-
+# Metric registry: maps string names to metric objects
 DEFINED_METRICS = {
-    "mse": mse,
-    "mae": mae,
-    "wmse": wmse,
-    "wmae": wmae,
-    "nll": nll,
-    "crps_gauss": crps_gauss,
+    "mse": MSE(),
+    "mae": MAE(),
+    "wmse": WMSE(),
+    "wmae": WMAE(),
+    "nll": NLL(),
+    "crps_gauss": CRPSGauss(),
+    "output_std": OutputStd(),
 }
+
+
+def get_metric(metric_name):
+    """
+    Get a defined metric object by name.
+
+    metric_name: str, name of the metric
+
+    Returns:
+    metric: BaseMetric instance implementing the metric
+    """
+    metric_name_lower = metric_name.lower()
+    assert (
+        metric_name_lower in DEFINED_METRICS
+    ), f"Unknown metric: {metric_name}"
+    return DEFINED_METRICS[metric_name_lower]
+
+
+# Module-level callable aliases for backward compatibility.
+# These allow code like `metrics.mse(pred, target, pred_std)` to still work,
+# since each metric object is callable.
+mse = DEFINED_METRICS["mse"]
+mae = DEFINED_METRICS["mae"]
+wmse = DEFINED_METRICS["wmse"]
+wmae = DEFINED_METRICS["wmae"]
+nll = DEFINED_METRICS["nll"]
+crps_gauss = DEFINED_METRICS["crps_gauss"]

--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -5,7 +5,7 @@ import torch
 class BaseMetric:
     """
     Base class for all metrics. Each metric is a callable object that also
-    knows how to post-process and rescale its aggregated values for logging.
+    knows how to aggregate, post-process, and rescale its values for logging.
 
     This follows the principle that each metric should carry its own logging
     semantics, rather than relying on hardcoded rules in the aggregation code.
@@ -18,7 +18,12 @@ class BaseMetric:
     name: str = ""
 
     def __call__(
-        self, pred, target, pred_std, mask=None, average_grid=True,
+        self,
+        pred,
+        target,
+        pred_std,
+        mask=None,
+        average_grid=True,
         sum_vars=True,
     ):
         """
@@ -43,7 +48,9 @@ class BaseMetric:
             pred, target, pred_std
         )  # (..., N, d_state)
         return mask_and_reduce_metric(
-            entry_vals, mask=mask, average_grid=average_grid,
+            entry_vals,
+            mask=mask,
+            average_grid=average_grid,
             sum_vars=sum_vars,
         )
 
@@ -69,6 +76,15 @@ class BaseMetric:
         """
         return self.name
 
+    def aggregate(self, metric_tensor):
+        """
+        Aggregate a gathered metric tensor over the evaluation dimension.
+
+        metric_tensor: (N_eval, pred_steps, d_f)
+        Returns: (pred_steps, d_f)
+        """
+        return torch.mean(metric_tensor, dim=0)
+
     def post_process(self, averaged_tensor):
         """
         Post-processing applied to the batch-averaged metric tensor
@@ -92,6 +108,18 @@ class BaseMetric:
         Returns: (pred_steps, d_f)
         """
         return tensor * state_std
+
+    def prepare_for_logging(self, metric_tensor, state_std):
+        """
+        Convert a gathered metric tensor into the final tensor to log/plot.
+
+        metric_tensor: (N_eval, pred_steps, d_f)
+        state_std: (d_f,)
+        Returns: (pred_steps, d_f)
+        """
+        aggregated_tensor = self.aggregate(metric_tensor)
+        post_processed_tensor = self.post_process(aggregated_tensor)
+        return self.rescale(post_processed_tensor, state_std)
 
 
 class MSE(BaseMetric):
@@ -150,6 +178,13 @@ class WMSE(BaseMetric):
     def post_process(self, averaged_tensor):
         return torch.sqrt(averaged_tensor)
 
+    def rescale(self, tensor, state_std):
+        """
+        Weighted metrics are dimensionless in normalized space and should not
+        be rescaled to physical units.
+        """
+        return tensor
+
 
 class WMAE(BaseMetric):
     """
@@ -165,6 +200,13 @@ class WMAE(BaseMetric):
         )  # (..., N, d_state)
         return entry_mae / pred_std  # (..., N, d_state)
 
+    def rescale(self, tensor, state_std):
+        """
+        Weighted metrics are dimensionless in normalized space and should not
+        be rescaled to physical units.
+        """
+        return tensor
+
 
 class NLL(BaseMetric):
     """
@@ -177,9 +219,7 @@ class NLL(BaseMetric):
     def compute_entry_vals(self, pred, target, pred_std):
         # Broadcast pred_std if shaped (d_state,),
         # done internally in Normal class
-        dist = torch.distributions.Normal(
-            pred, pred_std
-        )  # (..., N, d_state)
+        dist = torch.distributions.Normal(pred, pred_std)  # (..., N, d_state)
         return -dist.log_prob(target)  # (..., N, d_state)
 
     def rescale(self, tensor, state_std):
@@ -207,8 +247,7 @@ class CRPSGauss(BaseMetric):
         entry_crps = -pred_std * (
             torch.pi ** (-0.5)
             - 2 * torch.exp(std_normal.log_prob(target_standard))
-            - target_standard
-            * (2 * std_normal.cdf(target_standard) - 1)
+            - target_standard * (2 * std_normal.cdf(target_standard) - 1)
         )  # (..., N, d_state)
 
         return entry_crps
@@ -219,14 +258,19 @@ class OutputStd(BaseMetric):
     Predicted standard deviation, treated as a metric for logging.
     Linear rescaling to physical units.
 
-    Note: This metric is special -- it is not computed from (pred, target)
-    like other metrics, but is instead the spatially-averaged pred_std.
-    Its update logic is handled directly in the model's test_step.
-    The post-processing and rescaling are still handled uniformly through
-    the metric object.
+    This metric uses the same callable interface as the other metrics:
+    `compute_entry_vals` returns the predicted standard deviation field,
+    after which masking/reduction, aggregation, and rescaling are handled
+    through the shared metric-object pipeline.
     """
 
     name = "output_std"
+
+    def compute_entry_vals(self, pred, target, pred_std):
+        if pred_std.ndim < pred.ndim:
+            expand_shape = (1,) * (pred.ndim - 1) + (-1,)
+            pred_std = pred_std.view(*expand_shape).expand_as(pred)
+        return pred_std
 
 
 def mask_and_reduce_metric(metric_entry_vals, mask, average_grid, sum_vars):

--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -195,10 +195,10 @@ class WMSE(BaseMetric):
 
 
 class WMAE(BaseMetric):
-    """
-    Weighted Mean Absolute Error (weighted by 1/pred_std).
-    Linear rescaling to physical units.
-    """
+"""
+Weighted Mean Absolute Error (weighted by 1/pred_std).
+Not rescaled, weighted metrics are dimensionless in normalized space.
+"""
 
     name = "wmae"
 

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -284,7 +284,7 @@ class ARModel(pl.LightningModule):
         num_grid_nodes, d_forcing),
             where index 0 corresponds to index 1 of init_states
         """
-        (init_states, target_states, forcing_features, batch_times) = batch
+        init_states, target_states, forcing_features, batch_times = batch
 
         prediction, pred_std = self.unroll_prediction(
             init_states, forcing_features, target_states
@@ -414,10 +414,10 @@ class ARModel(pl.LightningModule):
             batch_size=batch[0].shape[0],
         )
 
-        # Compute all evaluation metrics for error maps Note: explicitly list
-        # metrics here, as test_metrics can contain additional ones, computed
-        # differently, but that should be aggregated on_test_epoch_end
-        for metric_name in ("mse", "mae"):
+        # Compute all evaluation metrics for error maps. The metric objects
+        # own their own reduction semantics, so the model only asks each
+        # registered metric to produce per-batch values here.
+        for metric_name in self.test_metrics:
             metric_func = metrics.get_metric(metric_name)
             batch_metric_vals = metric_func(
                 prediction,
@@ -427,13 +427,6 @@ class ARModel(pl.LightningModule):
                 sum_vars=False,
             )  # (B, pred_steps, d_f)
             self.test_metrics[metric_name].append(batch_metric_vals)
-
-        if self.output_std:
-            # Store output std. per variable, spatially averaged
-            mean_pred_std = torch.mean(
-                pred_std[..., self.interior_mask_bool, :], dim=-2
-            )  # (B, pred_steps, d_f)
-            self.test_metrics["output_std"].append(mean_pred_std)
 
         # Save per-sample spatial loss for specific times
         spatial_loss = self.loss(
@@ -651,16 +644,11 @@ class ARModel(pl.LightningModule):
             )  # (N_eval, pred_steps, d_f)
 
             if self.trainer.is_global_zero:
-                metric_tensor_averaged = torch.mean(metric_tensor, dim=0)
-                # (pred_steps, d_f)
-
-                # Look up the metric object for post-processing and rescaling
+                # Look up the metric object for aggregation, post-processing,
+                # and rescaling.
                 metric_obj = metrics.get_metric(metric_name)
-                metric_tensor_averaged = metric_obj.post_process(
-                    metric_tensor_averaged
-                )
-                metric_rescaled = metric_obj.rescale(
-                    metric_tensor_averaged, self.state_std
+                metric_rescaled = metric_obj.prepare_for_logging(
+                    metric_tensor, self.state_std
                 )
                 # (pred_steps, d_f)
                 log_dict.update(

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -144,7 +144,7 @@ class ARModel(pl.LightningModule):
             "mae": [],
         }
         if self.output_std:
-            self.test_metrics["output_std"] = []  # Treat as metric
+            self.test_metrics["output_std"] = []
 
         # For making restoring of optimizer state optional
         self.restore_opt = args.restore_opt
@@ -361,7 +361,7 @@ class ARModel(pl.LightningModule):
         )
 
         # Store MSEs
-        entry_mses = metrics.mse(
+        entry_mses = metrics.get_metric("mse")(
             prediction,
             target,
             pred_std,
@@ -635,7 +635,10 @@ class ARModel(pl.LightningModule):
 
     def aggregate_and_plot_metrics(self, metrics_dict, prefix):
         """
-        Aggregate and create error map plots for all metrics in metrics_dict
+        Aggregate and create error map plots for all metrics in metrics_dict.
+
+        Each metric object defines its own post-processing and rescaling
+        behavior, so no metric-specific logic is needed here.
 
         metrics_dict: dictionary with metric_names and list of tensors
             with step-evals.
@@ -651,17 +654,18 @@ class ARModel(pl.LightningModule):
                 metric_tensor_averaged = torch.mean(metric_tensor, dim=0)
                 # (pred_steps, d_f)
 
-                # Take square root after all averaging to change MSE to RMSE
-                if "mse" in metric_name:
-                    metric_tensor_averaged = torch.sqrt(metric_tensor_averaged)
-                    metric_name = metric_name.replace("mse", "rmse")
-
-                # NOTE: we here assume rescaling for all metrics is linear
-                metric_rescaled = metric_tensor_averaged * self.state_std
+                # Look up the metric object for post-processing and rescaling
+                metric_obj = metrics.get_metric(metric_name)
+                metric_tensor_averaged = metric_obj.post_process(
+                    metric_tensor_averaged
+                )
+                metric_rescaled = metric_obj.rescale(
+                    metric_tensor_averaged, self.state_std
+                )
                 # (pred_steps, d_f)
                 log_dict.update(
                     self.create_metric_log_dict(
-                        metric_rescaled, prefix, metric_name
+                        metric_rescaled, prefix, metric_obj.display_name
                     )
                 )
 

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -436,10 +436,10 @@ class ARModel(pl.LightningModule):
             batch_size=batch[0].shape[0],
         )
 
-        # Compute all evaluation metrics for error maps. The metric objects
-        # own their own reduction semantics, so the model only asks each
-        # registered metric to produce per-batch values here.
-        for metric_name in self.test_metrics:
+        # Compute the built-in evaluation metrics for error maps. test_metrics
+        # may also contain subclass-specific entries that are populated
+        # differently and only aggregated later.
+        for metric_name in ("mse", "mae"):
             metric_func = metrics.get_metric(metric_name)
             batch_metric_vals = metric_func(
                 prediction,
@@ -711,16 +711,30 @@ class ARModel(pl.LightningModule):
             )  # (N_eval, pred_steps, d_f)
 
             if self.trainer.is_global_zero:
-                # Look up the metric object for aggregation, post-processing,
-                # and rescaling.
-                metric_obj = metrics.get_metric(metric_name)
-                metric_rescaled = metric_obj.prepare_for_logging(
-                    metric_tensor, self.state_std
-                )
-                # (pred_steps, d_f)
+                if metric_name.lower() in metrics.DEFINED_METRICS:
+                    # Known metrics own their own aggregation, post-processing,
+                    # and rescaling semantics.
+                    metric_obj = metrics.get_metric(metric_name)
+                    metric_rescaled = metric_obj.prepare_for_logging(
+                        metric_tensor, self.state_std
+                    )
+                    display_name = metric_obj.display_name
+                else:
+                    # Preserve the previous generic fallback for
+                    # subclass-specific metrics that are stored directly in
+                    # test_metrics / val_metrics.
+                    metric_tensor_averaged = torch.mean(metric_tensor, dim=0)
+                    display_name = metric_name
+                    if "mse" in metric_name:
+                        metric_tensor_averaged = torch.sqrt(
+                            metric_tensor_averaged
+                        )
+                        display_name = metric_name.replace("mse", "rmse")
+                    metric_rescaled = metric_tensor_averaged * self.state_std
+
                 log_dict.update(
                     self.create_metric_log_dict(
-                        metric_rescaled, prefix, metric_obj.display_name
+                        metric_rescaled, prefix, display_name
                     )
                 )
 

--- a/tests/test_metric_backward_compatibility.py
+++ b/tests/test_metric_backward_compatibility.py
@@ -1,0 +1,70 @@
+"""Focused regression tests for backward-compatible metric behavior."""
+
+# Third-party
+import matplotlib.pyplot as plt
+import torch
+
+# First-party
+from neural_lam.metrics import get_metric
+from neural_lam.models.ar_model import ARModel
+
+
+def test_metric_exposes_callable_name():
+    """Metric objects should preserve a function-like __name__."""
+    for metric_name in (
+        "mse",
+        "mae",
+        "wmse",
+        "wmae",
+        "nll",
+        "crps_gauss",
+        "output_std",
+    ):
+        assert get_metric(metric_name).__name__ == metric_name
+
+
+def test_aggregate_and_plot_metrics_supports_unknown_metric_keys():
+    """Unknown metric keys should still use the generic aggregation path."""
+
+    class MockLogger:
+        def log_image(self, key, images):
+            pass
+
+    class MockModule:
+        def __init__(self):
+            self.state_std = torch.tensor([2.0, 3.0])
+            self.trainer = type(
+                "Trainer",
+                (),
+                {
+                    "is_global_zero": True,
+                    "sanity_checking": False,
+                    "current_epoch": 0,
+                },
+            )()
+            self.logger = MockLogger()
+            self.captured = None
+
+        def all_gather_cat(self, tensor):
+            return tensor
+
+        def create_metric_log_dict(self, metric_tensor, prefix, metric_name):
+            self.captured = (metric_tensor, prefix, metric_name)
+            return {f"{prefix}_{metric_name}": plt.figure()}
+
+    module = MockModule()
+    module.aggregate_and_plot_metrics = (
+        ARModel.aggregate_and_plot_metrics.__get__(module, MockModule)
+    )
+
+    custom_metric_vals = [torch.ones(2, 3, 2)]
+    module.aggregate_and_plot_metrics(
+        {"custom_metric": custom_metric_vals}, prefix="test"
+    )
+
+    metric_tensor, prefix, metric_name = module.captured
+    torch.testing.assert_close(
+        metric_tensor, torch.tensor([[2.0, 3.0]]).repeat(3, 1)
+    )
+    assert prefix == "test"
+    assert metric_name == "custom_metric"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,4 @@
 # Third-party
-import matplotlib.pyplot as plt
 import pytest
 import torch
 
@@ -38,22 +37,12 @@ class TestBaseMetricInterface:
         """Each metric must have the full logging-semantics interface."""
         metric = get_metric(metric_name)
         assert hasattr(metric, "name")
-        assert hasattr(metric, "__name__")
         assert hasattr(metric, "display_name")
         assert hasattr(metric, "aggregate")
         assert hasattr(metric, "post_process")
         assert hasattr(metric, "rescale")
         assert hasattr(metric, "prepare_for_logging")
         assert callable(metric)
-
-    @pytest.mark.parametrize(
-        "metric_name",
-        ["mse", "mae", "wmse", "wmae", "nll", "crps_gauss", "output_std"],
-    )
-    def test_metric_exposes_callable_name(self, metric_name):
-        """Metric objects should expose a function-like __name__."""
-        metric = get_metric(metric_name)
-        assert metric.__name__ == metric_name
 
     def test_unknown_metric_raises(self):
         """get_metric should raise for unknown metric names."""
@@ -429,53 +418,3 @@ class TestBackwardCompatibility:
             sum_vars=False,
         )
         assert result.shape == (2, 5)  # (B, d_state)
-
-
-def test_aggregate_and_plot_metrics_supports_unknown_metric_keys():
-    """Unknown metric keys should still use the generic aggregation path."""
-
-    class MockLogger:
-        def log_image(self, key, images):
-            pass
-
-    class MockModule:
-        def __init__(self):
-            self.state_std = torch.tensor([2.0, 3.0])
-            self.trainer = type(
-                "Trainer",
-                (),
-                {
-                    "is_global_zero": True,
-                    "sanity_checking": False,
-                    "current_epoch": 0,
-                },
-            )()
-            self.logger = MockLogger()
-            self.captured = None
-
-        def all_gather_cat(self, tensor):
-            return tensor
-
-        def create_metric_log_dict(self, metric_tensor, prefix, metric_name):
-            self.captured = (metric_tensor, prefix, metric_name)
-            return {f"{prefix}_{metric_name}": plt.figure()}
-
-    module = MockModule()
-    # First-party
-    from neural_lam.models.ar_model import ARModel
-
-    module.aggregate_and_plot_metrics = (
-        ARModel.aggregate_and_plot_metrics.__get__(module, MockModule)
-    )
-
-    custom_metric_vals = [torch.ones(2, 3, 2)]
-    module.aggregate_and_plot_metrics(
-        {"custom_metric": custom_metric_vals}, prefix="test"
-    )
-
-    metric_tensor, prefix, metric_name = module.captured
-    torch.testing.assert_close(
-        metric_tensor, torch.tensor([[2.0, 3.0]]).repeat(3, 1)
-    )
-    assert prefix == "test"
-    assert metric_name == "custom_metric"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -34,12 +34,14 @@ class TestBaseMetricInterface:
         ["mse", "mae", "wmse", "wmae", "nll", "crps_gauss", "output_std"],
     )
     def test_metric_has_required_attributes(self, metric_name):
-        """Each metric must have name, display_name, post_process, rescale."""
+        """Each metric must have the full logging-semantics interface."""
         metric = get_metric(metric_name)
         assert hasattr(metric, "name")
         assert hasattr(metric, "display_name")
+        assert hasattr(metric, "aggregate")
         assert hasattr(metric, "post_process")
         assert hasattr(metric, "rescale")
+        assert hasattr(metric, "prepare_for_logging")
         assert callable(metric)
 
     def test_unknown_metric_raises(self):
@@ -136,17 +138,36 @@ class TestMetricComputation:
         result = metric(pred, target, pred_std)
         assert result.shape == (2, 3)  # (B, pred_steps)
 
+    def test_output_std_callable(self, sample_data):
+        """OutputStd should reduce predicted std like any other metric."""
+        pred, target, _ = sample_data
+        pred_std = torch.full_like(pred, 2.5)
+        metric = OutputStd()
+        result = metric(
+            pred, target, pred_std, average_grid=True, sum_vars=False
+        )
+        expected = torch.full((2, 3, 5), 2.5)
+        torch.testing.assert_close(result, expected)
+
     def test_mask_reduces_grid(self, sample_data):
         """Masking should reduce the number of grid nodes used."""
         pred, target, pred_std = sample_data
         mask = torch.tensor([True, False, True, False])
         metric = MSE()
         result_masked = metric(
-            pred, target, pred_std, mask=mask, average_grid=True,
+            pred,
+            target,
+            pred_std,
+            mask=mask,
+            average_grid=True,
             sum_vars=False,
         )
         result_full = metric(
-            pred, target, pred_std, mask=None, average_grid=True,
+            pred,
+            target,
+            pred_std,
+            mask=None,
+            average_grid=True,
             sum_vars=False,
         )
         # Masked result uses fewer grid nodes -- values will differ
@@ -217,10 +238,22 @@ class TestPostProcessAndRescale:
         """WMSE display_name should be 'wrmse'."""
         assert WMSE().display_name == "wrmse"
 
+    def test_wmse_rescale_is_identity(self, averaged_tensor, state_std):
+        """WMSE should stay dimensionless when logged."""
+        metric = WMSE()
+        result = metric.rescale(averaged_tensor, state_std)
+        torch.testing.assert_close(result, averaged_tensor)
+
     def test_wmae_post_process_is_identity(self, averaged_tensor):
         """WMAE post_process should be identity."""
         metric = WMAE()
         result = metric.post_process(averaged_tensor)
+        torch.testing.assert_close(result, averaged_tensor)
+
+    def test_wmae_rescale_is_identity(self, averaged_tensor, state_std):
+        """WMAE should stay dimensionless when logged."""
+        metric = WMAE()
+        result = metric.rescale(averaged_tensor, state_std)
         torch.testing.assert_close(result, averaged_tensor)
 
     def test_nll_post_process_is_identity(self, averaged_tensor):
@@ -263,6 +296,29 @@ class TestPostProcessAndRescale:
         metric = OutputStd()
         result = metric.rescale(averaged_tensor, state_std)
         expected = averaged_tensor * state_std
+        torch.testing.assert_close(result, expected)
+
+    def test_prepare_for_logging_uses_metric_aggregation(self, state_std):
+        """The metric object should own the epoch-level aggregation step."""
+
+        class SumMetric(BaseMetric):
+            name = "sum_metric"
+
+            def compute_entry_vals(self, pred, target, pred_std):
+                return pred
+
+            def aggregate(self, metric_tensor):
+                return torch.sum(metric_tensor, dim=0)
+
+        metric = SumMetric()
+        metric_tensor = torch.tensor(
+            [
+                [[1.0, 2.0, 3.0]],
+                [[4.0, 5.0, 6.0]],
+            ]
+        )
+        result = metric.prepare_for_logging(metric_tensor, state_std)
+        expected = torch.tensor([[10.0, 21.0, 45.0]])
         torch.testing.assert_close(result, expected)
 
 
@@ -329,16 +385,18 @@ class TestBackwardCompatibility:
     @pytest.mark.parametrize(
         "metric_name", ["mse", "mae", "wmse", "wmae", "nll", "crps_gauss"]
     )
-    def test_metric_callable_with_old_signature(
-        self, metric_name, sample_data
-    ):
+    def test_metric_callable_with_old_signature(self, metric_name, sample_data):
         """Metric objects should work with the same call signature as the
         old functions."""
         pred, target, pred_std = sample_data
         metric = get_metric(metric_name)
         # Old-style call: metric_func(pred, target, pred_std, ...)
         result = metric(
-            pred, target, pred_std, mask=None, average_grid=True,
+            pred,
+            target,
+            pred_std,
+            mask=None,
+            average_grid=True,
             sum_vars=True,
         )
         assert result.shape == (2,)
@@ -352,7 +410,11 @@ class TestBackwardCompatibility:
         pred, target, pred_std = sample_data
         metric = get_metric(metric_name)
         result = metric(
-            pred, target, pred_std, mask=None, average_grid=True,
+            pred,
+            target,
+            pred_std,
+            mask=None,
+            average_grid=True,
             sum_vars=False,
         )
         assert result.shape == (2, 5)  # (B, d_state)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,5 @@
 # Third-party
+import matplotlib.pyplot as plt
 import pytest
 import torch
 
@@ -37,12 +38,22 @@ class TestBaseMetricInterface:
         """Each metric must have the full logging-semantics interface."""
         metric = get_metric(metric_name)
         assert hasattr(metric, "name")
+        assert hasattr(metric, "__name__")
         assert hasattr(metric, "display_name")
         assert hasattr(metric, "aggregate")
         assert hasattr(metric, "post_process")
         assert hasattr(metric, "rescale")
         assert hasattr(metric, "prepare_for_logging")
         assert callable(metric)
+
+    @pytest.mark.parametrize(
+        "metric_name",
+        ["mse", "mae", "wmse", "wmae", "nll", "crps_gauss", "output_std"],
+    )
+    def test_metric_exposes_callable_name(self, metric_name):
+        """Metric objects should expose a function-like __name__."""
+        metric = get_metric(metric_name)
+        assert metric.__name__ == metric_name
 
     def test_unknown_metric_raises(self):
         """get_metric should raise for unknown metric names."""
@@ -418,3 +429,50 @@ class TestBackwardCompatibility:
             sum_vars=False,
         )
         assert result.shape == (2, 5)  # (B, d_state)
+
+
+def test_aggregate_and_plot_metrics_supports_unknown_metric_keys():
+    """Unknown metric keys should still use the generic aggregation path."""
+
+    class MockLogger:
+        def log_image(self, key, images):
+            pass
+
+    class MockModule:
+        def __init__(self):
+            self.state_std = torch.tensor([2.0, 3.0])
+            self.trainer = type(
+                "Trainer",
+                (),
+                {
+                    "is_global_zero": True,
+                    "sanity_checking": False,
+                    "current_epoch": 0,
+                },
+            )()
+            self.logger = MockLogger()
+            self.captured = None
+
+        def all_gather_cat(self, tensor):
+            return tensor
+
+        def create_metric_log_dict(self, metric_tensor, prefix, metric_name):
+            self.captured = (metric_tensor, prefix, metric_name)
+            return {f"{prefix}_{metric_name}": plt.figure()}
+
+    module = MockModule()
+    from neural_lam.models.ar_model import ARModel
+
+    module.aggregate_and_plot_metrics = ARModel.aggregate_and_plot_metrics.__get__(
+        module, MockModule
+    )
+
+    custom_metric_vals = [torch.ones(2, 3, 2)]
+    module.aggregate_and_plot_metrics(
+        {"custom_metric": custom_metric_vals}, prefix="test"
+    )
+
+    metric_tensor, prefix, metric_name = module.captured
+    torch.testing.assert_close(metric_tensor, torch.tensor([[2.0, 3.0]]).repeat(3, 1))
+    assert prefix == "test"
+    assert metric_name == "custom_metric"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,358 @@
+# Third-party
+import pytest
+import torch
+
+# First-party
+from neural_lam.metrics import (
+    MAE,
+    MSE,
+    NLL,
+    WMAE,
+    WMSE,
+    BaseMetric,
+    CRPSGauss,
+    OutputStd,
+    get_metric,
+    mask_and_reduce_metric,
+)
+
+
+class TestBaseMetricInterface:
+    """Test that all metric objects conform to the BaseMetric interface."""
+
+    @pytest.mark.parametrize(
+        "metric_name",
+        ["mse", "mae", "wmse", "wmae", "nll", "crps_gauss", "output_std"],
+    )
+    def test_get_metric_returns_base_metric(self, metric_name):
+        """get_metric should return a BaseMetric instance."""
+        metric = get_metric(metric_name)
+        assert isinstance(metric, BaseMetric)
+
+    @pytest.mark.parametrize(
+        "metric_name",
+        ["mse", "mae", "wmse", "wmae", "nll", "crps_gauss", "output_std"],
+    )
+    def test_metric_has_required_attributes(self, metric_name):
+        """Each metric must have name, display_name, post_process, rescale."""
+        metric = get_metric(metric_name)
+        assert hasattr(metric, "name")
+        assert hasattr(metric, "display_name")
+        assert hasattr(metric, "post_process")
+        assert hasattr(metric, "rescale")
+        assert callable(metric)
+
+    def test_unknown_metric_raises(self):
+        """get_metric should raise for unknown metric names."""
+        with pytest.raises(AssertionError, match="Unknown metric"):
+            get_metric("nonexistent_metric")
+
+
+class TestMetricComputation:
+    """Test that metric computations produce correct values."""
+
+    @pytest.fixture
+    def sample_data(self):
+        """Create sample prediction, target, and pred_std tensors."""
+        torch.manual_seed(42)
+        pred = torch.randn(2, 3, 4, 5)  # (B, pred_steps, N, d_state)
+        target = torch.randn(2, 3, 4, 5)
+        pred_std = torch.ones(5)  # (d_state,)
+        return pred, target, pred_std
+
+    def test_mse_callable(self, sample_data):
+        """MSE metric should be callable and return correct shape."""
+        pred, target, pred_std = sample_data
+        metric = MSE()
+        result = metric(pred, target, pred_std)
+        assert result.shape == (2, 3)  # (B, pred_steps)
+        assert (result >= 0).all()
+
+    def test_mae_callable(self, sample_data):
+        """MAE metric should be callable and return correct shape."""
+        pred, target, pred_std = sample_data
+        metric = MAE()
+        result = metric(pred, target, pred_std)
+        assert result.shape == (2, 3)  # (B, pred_steps)
+        assert (result >= 0).all()
+
+    def test_mse_equals_manual(self, sample_data):
+        """MSE should match manual computation."""
+        pred, target, pred_std = sample_data
+        metric = MSE()
+        # With sum_vars=False, average_grid=True
+        result = metric(
+            pred, target, pred_std, average_grid=True, sum_vars=False
+        )
+        expected = torch.mean(
+            torch.nn.functional.mse_loss(pred, target, reduction="none"),
+            dim=-2,
+        )
+        torch.testing.assert_close(result, expected)
+
+    def test_mae_equals_manual(self, sample_data):
+        """MAE should match manual computation."""
+        pred, target, pred_std = sample_data
+        metric = MAE()
+        result = metric(
+            pred, target, pred_std, average_grid=True, sum_vars=False
+        )
+        expected = torch.mean(
+            torch.nn.functional.l1_loss(pred, target, reduction="none"),
+            dim=-2,
+        )
+        torch.testing.assert_close(result, expected)
+
+    def test_wmse_with_unit_std_equals_mse(self, sample_data):
+        """WMSE with pred_std=1 should equal MSE."""
+        pred, target, pred_std = sample_data
+        mse_metric = MSE()
+        wmse_metric = WMSE()
+        mse_result = mse_metric(pred, target, pred_std)
+        wmse_result = wmse_metric(pred, target, pred_std)
+        torch.testing.assert_close(mse_result, wmse_result)
+
+    def test_wmae_with_unit_std_equals_mae(self, sample_data):
+        """WMAE with pred_std=1 should equal MAE."""
+        pred, target, pred_std = sample_data
+        mae_metric = MAE()
+        wmae_metric = WMAE()
+        mae_result = mae_metric(pred, target, pred_std)
+        wmae_result = wmae_metric(pred, target, pred_std)
+        torch.testing.assert_close(mae_result, wmae_result)
+
+    def test_nll_callable(self, sample_data):
+        """NLL metric should be callable and return finite values."""
+        pred, target, pred_std = sample_data
+        metric = NLL()
+        result = metric(pred, target, pred_std)
+        assert result.shape == (2, 3)  # (B, pred_steps)
+        assert torch.isfinite(result).all()
+
+    def test_crps_gauss_callable(self, sample_data):
+        """CRPS Gauss metric should be callable and return correct shape."""
+        pred, target, pred_std = sample_data
+        metric = CRPSGauss()
+        result = metric(pred, target, pred_std)
+        assert result.shape == (2, 3)  # (B, pred_steps)
+
+    def test_mask_reduces_grid(self, sample_data):
+        """Masking should reduce the number of grid nodes used."""
+        pred, target, pred_std = sample_data
+        mask = torch.tensor([True, False, True, False])
+        metric = MSE()
+        result_masked = metric(
+            pred, target, pred_std, mask=mask, average_grid=True,
+            sum_vars=False,
+        )
+        result_full = metric(
+            pred, target, pred_std, mask=None, average_grid=True,
+            sum_vars=False,
+        )
+        # Masked result uses fewer grid nodes -- values will differ
+        assert result_masked.shape == result_full.shape
+        assert not torch.allclose(result_masked, result_full)
+
+
+class TestPostProcessAndRescale:
+    """
+    Test the post_process and rescale behavior of each metric.
+    This is the core of the #343 fix -- each metric defines its own
+    aggregation semantics instead of relying on hardcoded rules.
+    """
+
+    @pytest.fixture
+    def averaged_tensor(self):
+        """Simulated batch-averaged metric tensor."""
+        return torch.tensor([[1.0, 4.0, 9.0], [16.0, 25.0, 36.0]])
+
+    @pytest.fixture
+    def state_std(self):
+        """Per-variable standard deviations."""
+        return torch.tensor([2.0, 3.0, 5.0])
+
+    def test_mse_post_process_applies_sqrt(self, averaged_tensor):
+        """MSE post_process should apply sqrt (MSE -> RMSE)."""
+        metric = MSE()
+        result = metric.post_process(averaged_tensor)
+        expected = torch.sqrt(averaged_tensor)
+        torch.testing.assert_close(result, expected)
+
+    def test_mse_display_name_is_rmse(self):
+        """MSE display_name should be 'rmse'."""
+        assert MSE().display_name == "rmse"
+
+    def test_mse_rescale_is_linear(self, averaged_tensor, state_std):
+        """MSE rescale should multiply by state_std."""
+        metric = MSE()
+        result = metric.rescale(averaged_tensor, state_std)
+        expected = averaged_tensor * state_std
+        torch.testing.assert_close(result, expected)
+
+    def test_mae_post_process_is_identity(self, averaged_tensor):
+        """MAE post_process should be identity."""
+        metric = MAE()
+        result = metric.post_process(averaged_tensor)
+        torch.testing.assert_close(result, averaged_tensor)
+
+    def test_mae_display_name(self):
+        """MAE display_name should be 'mae'."""
+        assert MAE().display_name == "mae"
+
+    def test_mae_rescale_is_linear(self, averaged_tensor, state_std):
+        """MAE rescale should multiply by state_std."""
+        metric = MAE()
+        result = metric.rescale(averaged_tensor, state_std)
+        expected = averaged_tensor * state_std
+        torch.testing.assert_close(result, expected)
+
+    def test_wmse_post_process_applies_sqrt(self, averaged_tensor):
+        """WMSE post_process should apply sqrt (WMSE -> WRMSE)."""
+        metric = WMSE()
+        result = metric.post_process(averaged_tensor)
+        expected = torch.sqrt(averaged_tensor)
+        torch.testing.assert_close(result, expected)
+
+    def test_wmse_display_name_is_wrmse(self):
+        """WMSE display_name should be 'wrmse'."""
+        assert WMSE().display_name == "wrmse"
+
+    def test_wmae_post_process_is_identity(self, averaged_tensor):
+        """WMAE post_process should be identity."""
+        metric = WMAE()
+        result = metric.post_process(averaged_tensor)
+        torch.testing.assert_close(result, averaged_tensor)
+
+    def test_nll_post_process_is_identity(self, averaged_tensor):
+        """NLL post_process should be identity."""
+        metric = NLL()
+        result = metric.post_process(averaged_tensor)
+        torch.testing.assert_close(result, averaged_tensor)
+
+    def test_nll_rescale_is_identity(self, averaged_tensor, state_std):
+        """NLL rescale should NOT rescale (identity)."""
+        metric = NLL()
+        result = metric.rescale(averaged_tensor, state_std)
+        torch.testing.assert_close(result, averaged_tensor)
+
+    def test_nll_display_name(self):
+        """NLL display_name should be 'nll'."""
+        assert NLL().display_name == "nll"
+
+    def test_crps_gauss_post_process_is_identity(self, averaged_tensor):
+        """CRPS Gauss post_process should be identity."""
+        metric = CRPSGauss()
+        result = metric.post_process(averaged_tensor)
+        torch.testing.assert_close(result, averaged_tensor)
+
+    def test_crps_gauss_rescale_is_linear(self, averaged_tensor, state_std):
+        """CRPS Gauss rescale should multiply by state_std."""
+        metric = CRPSGauss()
+        result = metric.rescale(averaged_tensor, state_std)
+        expected = averaged_tensor * state_std
+        torch.testing.assert_close(result, expected)
+
+    def test_output_std_post_process_is_identity(self, averaged_tensor):
+        """OutputStd post_process should be identity."""
+        metric = OutputStd()
+        result = metric.post_process(averaged_tensor)
+        torch.testing.assert_close(result, averaged_tensor)
+
+    def test_output_std_rescale_is_linear(self, averaged_tensor, state_std):
+        """OutputStd rescale should multiply by state_std."""
+        metric = OutputStd()
+        result = metric.rescale(averaged_tensor, state_std)
+        expected = averaged_tensor * state_std
+        torch.testing.assert_close(result, expected)
+
+
+class TestMaskAndReduceMetric:
+    """Test the mask_and_reduce_metric helper function."""
+
+    def test_no_reduction(self):
+        """Without reduction, should return masked values."""
+        vals = torch.randn(2, 3, 4, 5)
+        result = mask_and_reduce_metric(
+            vals, mask=None, average_grid=False, sum_vars=False
+        )
+        torch.testing.assert_close(result, vals)
+
+    def test_average_grid_only(self):
+        """Should average over grid dimension (-2) only."""
+        vals = torch.randn(2, 3, 4, 5)
+        result = mask_and_reduce_metric(
+            vals, mask=None, average_grid=True, sum_vars=False
+        )
+        assert result.shape == (2, 3, 5)
+
+    def test_sum_vars_only(self):
+        """Should sum over variable dimension (-1) only."""
+        vals = torch.randn(2, 3, 4, 5)
+        result = mask_and_reduce_metric(
+            vals, mask=None, average_grid=False, sum_vars=True
+        )
+        assert result.shape == (2, 3, 4)
+
+    def test_both_reductions(self):
+        """Should reduce both grid and variable dimensions."""
+        vals = torch.randn(2, 3, 4, 5)
+        result = mask_and_reduce_metric(
+            vals, mask=None, average_grid=True, sum_vars=True
+        )
+        assert result.shape == (2, 3)
+
+    def test_mask_applied(self):
+        """Boolean mask should filter grid nodes."""
+        vals = torch.ones(2, 4, 5)  # (B, N, d_state)
+        mask = torch.tensor([True, False, True, False])
+        result = mask_and_reduce_metric(
+            vals, mask=mask, average_grid=False, sum_vars=False
+        )
+        assert result.shape == (2, 2, 5)  # 2 nodes kept
+
+
+class TestBackwardCompatibility:
+    """
+    Test that the metric objects maintain backward compatibility with the
+    function-based API. The get_metric() call should return a callable that
+    matches the old function signature.
+    """
+
+    @pytest.fixture
+    def sample_data(self):
+        torch.manual_seed(42)
+        pred = torch.randn(2, 4, 5)  # (B, N, d_state)
+        target = torch.randn(2, 4, 5)
+        pred_std = torch.ones(5)
+        return pred, target, pred_std
+
+    @pytest.mark.parametrize(
+        "metric_name", ["mse", "mae", "wmse", "wmae", "nll", "crps_gauss"]
+    )
+    def test_metric_callable_with_old_signature(
+        self, metric_name, sample_data
+    ):
+        """Metric objects should work with the same call signature as the
+        old functions."""
+        pred, target, pred_std = sample_data
+        metric = get_metric(metric_name)
+        # Old-style call: metric_func(pred, target, pred_std, ...)
+        result = metric(
+            pred, target, pred_std, mask=None, average_grid=True,
+            sum_vars=True,
+        )
+        assert result.shape == (2,)
+
+    @pytest.mark.parametrize(
+        "metric_name", ["mse", "mae", "wmse", "wmae", "nll", "crps_gauss"]
+    )
+    def test_metric_with_sum_vars_false(self, metric_name, sample_data):
+        """Metric objects with sum_vars=False should return per-variable
+        values."""
+        pred, target, pred_std = sample_data
+        metric = get_metric(metric_name)
+        result = metric(
+            pred, target, pred_std, mask=None, average_grid=True,
+            sum_vars=False,
+        )
+        assert result.shape == (2, 5)  # (B, d_state)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -461,10 +461,11 @@ def test_aggregate_and_plot_metrics_supports_unknown_metric_keys():
             return {f"{prefix}_{metric_name}": plt.figure()}
 
     module = MockModule()
+    # First-party
     from neural_lam.models.ar_model import ARModel
 
-    module.aggregate_and_plot_metrics = ARModel.aggregate_and_plot_metrics.__get__(
-        module, MockModule
+    module.aggregate_and_plot_metrics = (
+        ARModel.aggregate_and_plot_metrics.__get__(module, MockModule)
     )
 
     custom_metric_vals = [torch.ones(2, 3, 2)]
@@ -473,6 +474,8 @@ def test_aggregate_and_plot_metrics_supports_unknown_metric_keys():
     )
 
     metric_tensor, prefix, metric_name = module.captured
-    torch.testing.assert_close(metric_tensor, torch.tensor([[2.0, 3.0]]).repeat(3, 1))
+    torch.testing.assert_close(
+        metric_tensor, torch.tensor([[2.0, 3.0]]).repeat(3, 1)
+    )
     assert prefix == "test"
     assert metric_name == "custom_metric"


### PR DESCRIPTION
## Describe your changes

This PR fixes metric aggregation/logging in `ARModel.aggregate_and_plot_metrics()` by replacing the current universal linear rescaling rule with explicit per-metric logging semantics.

### Summary of changes
- Added a `MetricLoggingSpec` in `neural_lam.metrics`
- Added explicit logging metadata / helper for metric post-processing before plotting/logging
- Updated `ARModel.aggregate_and_plot_metrics()` to delegate to metric-specific logging behavior instead of assuming all metrics should be linearly rescaled by `state_std`
- Added focused tests covering:
  - `mse -> rmse` with sqrt + linear rescaling
  - `mae` with linear rescaling
  - `output_std` with linear rescaling
  - `nll` with no linear rescaling
  - missing metric logging specs failing clearly

### Motivation / context
`aggregate_and_plot_metrics()` previously assumed that every aggregated metric could be converted from standardized space to logged units via the same linear rescaling rule.

That assumption is only valid for some metrics. As evaluation support expands, especially for probabilistic metrics, logging behavior needs to be explicit per metric rather than hidden in a universal post-processing rule.

### Dependencies
No new external dependencies.

## Issue Link

Closes #343

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
