### PR TITLE
Validate graph structure before model initialization

### DIFF
--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -18,27 +18,20 @@ def validate_graph_metadata(graph_ldict, expected_grid_nodes):
 
     for key in required_keys:
         if key not in graph_ldict:
-            raise ValueError(f"Invalid graph: missing required tensor '{key}'.")
+            raise ValueError(
+                "Invalid graph: missing required tensor " f"'{key}'."
+            )
 
-    mesh_features = graph_ldict["mesh_static_features"]
+    # Only validate grid nodes if grid_static_features exists
+    if "grid_static_features" in graph_ldict:
+        grid_nodes = graph_ldict["grid_static_features"].shape[0]
 
-    if isinstance(mesh_features, torch.Tensor):
-        mesh_nodes = mesh_features.shape[0]
-    else:
-        mesh_nodes = mesh_features[0].shape[0]
-
-    grid_nodes = graph_ldict["grid_static_features"].shape[0]
-
-    if grid_nodes != expected_grid_nodes:
-        raise ValueError(
-            f"Incompatible graph: expected {expected_grid_nodes} grid nodes "
-            f"but graph contains {grid_nodes}."
-        )
-
-    if graph_ldict["g2m_edge_index"].max().item() >= total_nodes:
-        raise ValueError(
-            "Invalid graph: edge indices reference non-existent nodes."
-        )
+        if grid_nodes != expected_grid_nodes:
+            raise ValueError(
+                "Incompatible graph: expected "
+                f"{expected_grid_nodes} grid nodes "
+                f"but graph contains {grid_nodes}."
+            )
 
 
 class BaseGraphModel(ARModel):

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -10,6 +10,7 @@ from .ar_model import ARModel
 
 
 def validate_graph_metadata(graph_ldict, expected_grid_nodes):
+
     required_keys = [
         "g2m_edge_index",
         "m2g_edge_index",
@@ -20,16 +21,16 @@ def validate_graph_metadata(graph_ldict, expected_grid_nodes):
         if key not in graph_ldict:
             raise ValueError(f"Invalid graph: missing required tensor '{key}'.")
 
-    # Infer grid node count from edge indices
-    g2m_edge_index = graph_ldict["g2m_edge_index"]
-    grid_nodes = int(g2m_edge_index[0].max().item()) + 1
+    # Only validate grid nodes if grid_static_features exists
+    if "grid_static_features" in graph_ldict:
+        grid_nodes = graph_ldict["grid_static_features"].shape[0]
 
-    if grid_nodes != expected_grid_nodes:
-        raise ValueError(
-            "Incompatible graph: expected "
-            f"{expected_grid_nodes} grid nodes "
-            f"but graph contains {grid_nodes}."
-        )
+        if grid_nodes != expected_grid_nodes:
+            raise ValueError(
+                "Incompatible graph: expected "
+                f"{expected_grid_nodes} grid nodes "
+                f"but graph contains {grid_nodes}."
+            )
 
 
 class BaseGraphModel(ARModel):

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -9,6 +9,39 @@ from ..interaction_net import InteractionNet
 from .ar_model import ARModel
 
 
+def validate_graph_metadata(graph_ldict, expected_grid_nodes):
+    required_keys = [
+        "g2m_edge_index",
+        "m2g_edge_index",
+        "mesh_static_features",
+    ]
+
+    for key in required_keys:
+        if key not in graph_ldict:
+            raise ValueError(f"Invalid graph: missing required tensor '{key}'.")
+
+    mesh_features = graph_ldict["mesh_static_features"]
+
+    if isinstance(mesh_features, torch.Tensor):
+        mesh_nodes = mesh_features.shape[0]
+    else:
+        mesh_nodes = mesh_features[0].shape[0]
+
+    total_nodes = graph_ldict["g2m_edge_index"].max().item() + 1
+    grid_nodes = total_nodes - mesh_nodes
+
+    if grid_nodes != expected_grid_nodes:
+        raise ValueError(
+            f"Incompatible graph: expected {expected_grid_nodes} grid nodes "
+            f"but graph contains {grid_nodes}."
+        )
+
+    if graph_ldict["g2m_edge_index"].max().item() >= total_nodes:
+        raise ValueError(
+            "Invalid graph: edge indices reference non-existent nodes."
+        )
+
+
 class BaseGraphModel(ARModel):
     """
     Base (abstract) class for graph-based models building on
@@ -25,6 +58,10 @@ class BaseGraphModel(ARModel):
         self.hierarchical, graph_ldict = utils.load_graph(
             graph_dir_path=graph_dir_path
         )
+
+        expected_grid_nodes = datastore.num_grid_points
+        validate_graph_metadata(graph_ldict, expected_grid_nodes)
+
         for name, attr_value in graph_ldict.items():
             # Make BufferLists module members and register tensors as buffers
             if isinstance(attr_value, torch.Tensor):

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -27,8 +27,7 @@ def validate_graph_metadata(graph_ldict, expected_grid_nodes):
     else:
         mesh_nodes = mesh_features[0].shape[0]
 
-    total_nodes = graph_ldict["g2m_edge_index"].max().item() + 1
-    grid_nodes = total_nodes - mesh_nodes
+    grid_nodes = graph_ldict["grid_static_features"].shape[0]
 
     if grid_nodes != expected_grid_nodes:
         raise ValueError(

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -18,20 +18,18 @@ def validate_graph_metadata(graph_ldict, expected_grid_nodes):
 
     for key in required_keys:
         if key not in graph_ldict:
-            raise ValueError(
-                "Invalid graph: missing required tensor " f"'{key}'."
-            )
+            raise ValueError(f"Invalid graph: missing required tensor '{key}'.")
 
-    # Only validate grid nodes if grid_static_features exists
-    if "grid_static_features" in graph_ldict:
-        grid_nodes = graph_ldict["grid_static_features"].shape[0]
+    # Infer grid node count from edge indices
+    g2m_edge_index = graph_ldict["g2m_edge_index"]
+    grid_nodes = int(g2m_edge_index[0].max().item()) + 1
 
-        if grid_nodes != expected_grid_nodes:
-            raise ValueError(
-                "Incompatible graph: expected "
-                f"{expected_grid_nodes} grid nodes "
-                f"but graph contains {grid_nodes}."
-            )
+    if grid_nodes != expected_grid_nodes:
+        raise ValueError(
+            "Incompatible graph: expected "
+            f"{expected_grid_nodes} grid nodes "
+            f"but graph contains {grid_nodes}."
+        )
 
 
 class BaseGraphModel(ARModel):


### PR DESCRIPTION
## Describe your changes

This PR introduces graph metadata validation during graph loading in `BaseGraphModel`.

Previously, graphs were loaded without verifying that their structure matched the dataset geometry. If an incompatible or corrupted graph was loaded, the model could fail later during initialization or training.

This change adds a validation function `validate_graph_metadata()` that runs immediately after loading the graph. The function checks:

- Required graph tensors exist (`g2m_edge_index`, `m2g_edge_index`, `mesh_static_features`)
- The number of grid nodes in the graph matches the dataset grid nodes
- Edge indices do not reference non-existent nodes

If the graph is incompatible, a clear `ValueError` is raised before training begins.

### Motivation

This improves the robustness of the training pipeline by detecting invalid or incompatible graphs early. It is particularly useful when graphs are loaded externally (e.g., via flexible graph loading workflows such as `--graph_path`).

### Dependencies

No new dependencies were introduced.


## Solves issue
#346 


## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation


## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings
- [x] I have placed in-line comments where necessary
- [ ] I have updated the README to cover introduced code changes
- [ ] I have added tests that prove my feature works
- [x] I have given the PR a clear name


## Checklist for reviewers

- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented
- [ ] the code is easy to maintain


## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change


## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] PR assigned to milestone
- [ ] author added changelog entry