### PR TITLE
docs: improve docstring clarity for rank_zero_print utility

### DIFF
--- a/neural_lam/utils.py
+++ b/neural_lam/utils.py
@@ -307,7 +307,13 @@ def fractional_plot_bundle(fraction):
 
 @rank_zero_only
 def rank_zero_print(*args, **kwargs):
-    """Print only from rank 0 process"""
+    """
+    Print messages only from the rank-zero process in distributed runs.
+
+    This helper prevents duplicate log messages when training with
+    multiple processes or GPUs. Only the primary process (rank 0)
+    will output the message.
+    """
     print(*args, **kwargs)
 
 


### PR DESCRIPTION
**##Describe your changes**

This PR improves the docstring for the rank_zero_print utility function in neural_lam/utils.py.

The updated docstring explains that the function prints messages only from the rank-zero process during distributed training. This prevents duplicate log messages when running training across multiple GPUs or processes.

The goal of this change is to make the purpose and behavior of the function clearer for new users and contributors reading the code.

**##Issue Link**

Related to the documentation improvements discussed in PR #252.

**##Type of change**

 🐛 Bug fix (non-breaking change that fixes an issue)

 ✨ New feature (non-breaking change that adds functionality)

 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

 📖 Documentation (Addition or improvements to documentation)

**##Checklist before requesting a review**

 My branch is up-to-date with the target branch

 I have performed a self-review of my code

 For any new/modified functions/classes I have added docstrings that clearly describe their purpose

 I have given the PR a name that clearly describes the change




