### PR TITLE
Add docstring for download_meps_example_reduced_dataset helper

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,18 @@ TEST_DATA_KNOWN_HASH = (
 
 
 def download_meps_example_reduced_dataset():
+    """
+    Download and prepare the reduced MEPS example dataset used in tests.
+
+    The dataset is retrieved from an S3 bucket, extracted locally, and
+    standardization statistics are computed if the required files are
+    missing.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the datastore configuration file for the dataset.
+    """
     # Download and unzip test data into data/meps_example_reduced
     root_path = DATASTORE_EXAMPLES_ROOT_PATH / "npyfilesmeps"
     dataset_path = root_path / "meps_example_reduced"


### PR DESCRIPTION
## Describe your changes
This PR adds a docstring to the `download_meps_example_reduced_dataset`
helper function in `tests/conftest.py`.

The docstring clarifies the purpose of the function and describes the
returned value.

## Issue Link
Related to #252

## Type of change
- [x]  📖 Documentation