### PR TITLE
Fix docstring typos and replace assert with ValueError in get_metric

### DIFF
--- a/neural_lam/config.py
+++ b/neural_lam/config.py
@@ -89,10 +89,10 @@ class TrainingConfig:
     Attributes
     ----------
     state_feature_weighting : Union[ManualStateFeatureWeighting,
-                                    UnformFeatureWeighting]
+                                    UniformFeatureWeighting]
         The method to use for weighting the state features in the loss
-        function. Defaults to uniform weighting (`UnformFeatureWeighting`, i.e.
-        all features are weighted equally).
+        function. Defaults to uniform weighting (`UniformFeatureWeighting`,
+        i.e. all features are weighted equally).
     """
 
     state_feature_weighting: Union[

--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -12,9 +12,11 @@ def get_metric(metric_name):
     metric: function implementing the metric
     """
     metric_name_lower = metric_name.lower()
-    assert (
-        metric_name_lower in DEFINED_METRICS
-    ), f"Unknown metric: {metric_name}"
+    if metric_name_lower not in DEFINED_METRICS:
+        raise ValueError(
+            f"Unknown metric: '{metric_name}'. "
+            f"Available metrics: {list(DEFINED_METRICS.keys())}"
+        )
     return DEFINED_METRICS[metric_name_lower]
 
 

--- a/neural_lam/utils.py
+++ b/neural_lam/utils.py
@@ -105,7 +105,7 @@ def load_graph(graph_dir_path, device="cpu"):
     m2g_edge_index = loads_file("m2g_edge_index.pt")  # (2, M_m2g)
 
     n_levels = len(m2m_edge_index)
-    hierarchical = n_levels > 1  # Nor just single level mesh graph
+    hierarchical = n_levels > 1  # Not just single level mesh graph
 
     # Load static edge features
     # List of (M_m2m[l], d_edge_f)

--- a/neural_lam/vis.py
+++ b/neural_lam/vis.py
@@ -75,7 +75,7 @@ def plot_prediction(
     vrange=None,
 ):
     """
-    Plot example prediction and grond truth.
+    Plot example prediction and ground truth.
 
     Each has shape (N_grid,)
 

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -185,7 +185,8 @@ class WeatherDataset(torch.utils.data.Dataset):
     def _slice_state_time(self, da_state, idx, n_steps: int):
         """
         Produce a time slice of the given dataarray `da_state` (state) starting
-        at `idx` and with `n_steps` steps. An `offset`is calculated based on the
+        at `idx` and with `n_steps` steps. An `offset` is calculated based on
+        the
         `num_past_forcing_steps` class attribute. `Offset` is used to offset the
         start of the sample, to assert that enough previous time steps are
         available for the 2 initial states and any corresponding forcings
@@ -274,7 +275,8 @@ class WeatherDataset(torch.utils.data.Dataset):
         """
         # The current implementation requires at least 2 time steps for the
         # initial state (see GraphCast). The forcing data is windowed around the
-        # current autregressive time step. The two `init_steps` can also be used
+        # current autoregressive time step. The two `init_steps` can also be
+        # used
         # as past forcings.
         init_steps = 2
         da_list = []


### PR DESCRIPTION
## Describe your changes

Fix minor typos in several docstrings/comments and improve the input validation in `get_metric()`.
**Typo fixes**
- `neural_lam/config.py` (`TrainingConfig` docstring):  
  `UnformFeatureWeighting` → `UniformFeatureWeighting`.
- `neural_lam/vis.py` (`plot_prediction`):  
  “grond truth” → “ground truth”.
- `neural_lam/utils.py` (`load_graph`):  
  comment “Nor just single level mesh graph” → “Not just single level mesh graph”.
- `neural_lam/weather_dataset.py`:  
  `_slice_state_time` docstring: add missing space in “`offset` is”.  
  `_slice_forcing_time` docstring: “autregressive” → “autoregressive”.
**`get_metric` validation**
- `neural_lam/metrics.py`: replace the `assert` in `get_metric()` with a `ValueError` that lists the available metric names. Behaviour for valid metric names stays the same, but invalid names now raise a clear exception even when Python is run with `-O` (where asserts are stripped).

**Motivation / context**
These are small cleanups that make the docs a bit clearer and avoid a subtle failure mode where an unknown metric name would bypass the `assert` check in optimized runs and fail later with a less helpful error.

**Dependencies**
No new dependencies.

< Summary of the changes.>

< Please also include relevant motivation and context. >

< List any dependencies that are required for this change. >

## Issue Link

 closes #359

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
