### PR TITLE
Fix square mesh assumption in create_graph to support non-square domains

### DIFF
--- a/neural_lam/create_graph.py
+++ b/neural_lam/create_graph.py
@@ -256,17 +256,24 @@ def create_graph(
 
     # multi resolution tree levels
     G = []
-    mesh_dims = []  # for tracking per-level dimensions, used for reshape and dm
+    # for tracking per-level dimensions, used for reshape and dm
+    mesh_dims: list[tuple[int, int]] = []
     for lev in range(1, mesh_levels + 1):
-        n_larger = int(nleaf / (nx**lev))
-        # scale n_x and n_y proportionally to physical domain aspect ratio,
-        # assigning n_larger to whichever direction has greater physical extent
-        if x_extent >= y_extent:
-            n_x = n_larger
-            n_y = max(1, round(n_larger * y_extent / x_extent))
+        if lev == 1:
+            n_larger = int(nleaf / (nx**lev))
+            # scale n_x and n_y proportionally to physical domain aspect ratio,
+            # assign n_larger to whichever direction has greater physical extent
+            if x_extent >= y_extent:
+                n_x = n_larger
+                n_y = max(1, round(n_larger * y_extent / x_extent))
+            else:
+                n_y = n_larger
+                n_x = max(1, round(n_larger * x_extent / y_extent))
         else:
-            n_y = n_larger
-            n_x = max(1, round(n_larger * x_extent / y_extent))
+            # derive from actual slice of previous level
+            n_x_prev, n_y_prev = mesh_dims[lev - 2]
+            n_x = len(range(1, n_x_prev, nx))
+            n_y = len(range(1, n_y_prev, nx))
 
         if (n_y < 3 or n_x < 3) and lev > 1:  # always allow level 1
             mesh_levels = lev - 1
@@ -448,7 +455,16 @@ def create_graph(
     # distance between mesh nodes
     dx = x_extent / mesh_dims[0][0]  # cell width at finest mesh level
     dy = y_extent / mesh_dims[0][1]  # cell height at finest mesh level
-    dm = np.sqrt(dx**2 + dy**2)  # diagonal of mesh cell (coverage radius basis)
+
+    # compare using mesh_dims because dx dy can cause rounding issue
+    if mesh_dims[0][0] == mesh_dims[0][1]:
+        dm = np.sqrt(
+            np.sum((vm.data("pos")[(0, 1, 0)] - vm.data("pos")[(0, 0, 0)]) ** 2)
+        )
+    else:
+        dm = np.sqrt(
+            dx**2 + dy**2
+        )  # diagonal of mesh cell (coverage radius basis)
 
     # grid nodes
     Nx, Ny = xy.shape[:2]

--- a/neural_lam/create_graph.py
+++ b/neural_lam/create_graph.py
@@ -245,6 +245,8 @@ def create_graph(
     nlev = int(np.log(max(xy.shape[:2])) / np.log(nx))
     nleaf = nx**nlev  # leaves at the bottom = nleaf**2
 
+    x_extent = xy[:, :, 0].max() - xy[:, :, 0].min()
+    y_extent = xy[:, :, 1].max() - xy[:, :, 1].min()
     mesh_levels = nlev - 1
     if n_max_levels:
         # Limit the levels in mesh graph
@@ -254,14 +256,28 @@ def create_graph(
 
     # multi resolution tree levels
     G = []
+    mesh_dims = []  # for tracking per-level dimensions, used for reshape and dm
     for lev in range(1, mesh_levels + 1):
-        n = int(nleaf / (nx**lev))
-        g = mk_2d_graph(xy, n, n)
+        n_larger = int(nleaf / (nx**lev))
+        # scale n_x and n_y proportionally to physical domain aspect ratio,
+        # assigning n_larger to whichever direction has greater physical extent
+        if x_extent >= y_extent:
+            n_x = n_larger
+            n_y = max(1, round(n_larger * y_extent / x_extent))
+        else:
+            n_y = n_larger
+            n_x = max(1, round(n_larger * x_extent / y_extent))
+
+        if (n_y < 3 or n_x < 3) and lev > 1:  # always allow level 1
+            mesh_levels = lev - 1
+            break
+        g = mk_2d_graph(xy, n_x, n_y)
         if create_plot:
             plot_graph(from_networkx(g), title=f"Mesh graph, level {lev}")
             plt.show()
 
         G.append(g)
+        mesh_dims.append((n_x, n_y))
 
     if hierarchical:
         # Relabel nodes of each level with level index first
@@ -375,11 +391,12 @@ def create_graph(
         G_tot = G[0]
         for lev in range(1, len(G)):
             nodes = list(G[lev - 1].nodes)
-            n = int(np.sqrt(len(nodes)))
+            n_x_prev, n_y_prev = mesh_dims[lev - 1]
+            n_x_curr, n_y_curr = mesh_dims[lev]
             ij = (
                 np.array(nodes)
-                .reshape((n, n, 2))[1::nx, 1::nx, :]
-                .reshape(int(n / nx) ** 2, 2)
+                .reshape((n_x_prev, n_y_prev, 2))[1::nx, 1::nx, :]
+                .reshape(n_x_curr * n_y_curr, 2)
             )
             ij = [tuple(x) for x in ij]
             G[lev] = networkx.relabel_nodes(G[lev], dict(zip(G[lev].nodes, ij)))
@@ -429,9 +446,9 @@ def create_graph(
     vm = G_bottom_mesh.nodes
     vm_xy = np.array([xy for _, xy in vm.data("pos")])
     # distance between mesh nodes
-    dm = np.sqrt(
-        np.sum((vm.data("pos")[(0, 1, 0)] - vm.data("pos")[(0, 0, 0)]) ** 2)
-    )
+    dx = x_extent / mesh_dims[0][0]  # cell width at finest mesh level
+    dy = y_extent / mesh_dims[0][1]  # cell height at finest mesh level
+    dm = np.sqrt(dx**2 + dy**2)  # diagonal of mesh cell (coverage radius basis)
 
     # grid nodes
     Nx, Ny = xy.shape[:2]

--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -3,11 +3,12 @@ import tempfile
 from pathlib import Path
 
 # Third-party
+import numpy as np
 import pytest
 import torch
 
 # First-party
-from neural_lam.create_graph import create_graph_from_datastore
+from neural_lam.create_graph import create_graph, create_graph_from_datastore
 from neural_lam.datastore import DATASTORES
 from neural_lam.datastore.base import BaseRegularGridDatastore
 from tests.conftest import init_datastore_example
@@ -117,3 +118,24 @@ def test_graph_creation(datastore_name, graph_name):
                         assert r.shape[0] == 2  # adjacency matrix uses two rows
                     elif file_id.endswith("_features"):
                         assert r.shape[1] == d_features
+
+
+def test_graph_creation_non_square_aspect_ratio():
+    """
+    Mesh at level 1 should reflect the domain's aspect ratio, not be square.
+    """
+    Nx, Ny = 100, 600
+    x = np.linspace(0, 1, Nx)
+    y = np.linspace(0, 6, Ny)
+    xx, yy = np.meshgrid(x, y, indexing="ij")
+    xy = np.stack([xx, yy], axis=-1)  # (100, 600, 2)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        create_graph(graph_dir_path=tmpdir, xy=xy, n_max_levels=1)
+        mesh_features = torch.load(f"{tmpdir}/mesh_features.pt")
+        n_mesh_nodes = mesh_features[0].shape[0]
+
+    # With a square mesh, n_mesh_nodes would be n x n.
+    # With correct aspect ratio, n_y > n_x, so nodes < n_larger^2.
+    n_larger = int(3 ** int(np.log(max(Nx, Ny)) / np.log(3)) / 3)
+    assert n_mesh_nodes < n_larger**2

--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -139,3 +139,42 @@ def test_graph_creation_non_square_aspect_ratio():
     # With correct aspect ratio, n_y > n_x, so nodes < n_larger^2.
     n_larger = int(3 ** int(np.log(max(Nx, Ny)) / np.log(3)) / 3)
     assert n_mesh_nodes < n_larger**2
+
+
+def test_graph_creation_multiscale_non_square():
+    """
+    Multi-level rectangular mesh must not crash at reshape.
+    Mesh should also reflect the domain aspect ratio.
+    """
+    Nx, Ny = 100, 600
+    x = np.linspace(0, 1, Nx)
+    y = np.linspace(0, 6, Ny)
+    xx, yy = np.meshgrid(x, y, indexing="ij")
+    xy = np.stack([xx, yy], axis=-1)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        create_graph(graph_dir_path=tmpdir, xy=xy, n_max_levels=2)
+        mesh_features = torch.load(f"{tmpdir}/mesh_features.pt")
+        n_mesh_nodes = mesh_features[0].shape[0]
+
+    n_larger = int(3 ** int(np.log(max(Nx, Ny)) / np.log(3)) / 3)
+    assert n_mesh_nodes < n_larger**2
+
+
+def test_graph_creation_square_g2m_edges_unchanged():
+    """
+    Square grid g2m edge count must be preserved.
+    Edge count must use the original square formula over rectangular domains.
+    """
+    Nx, Ny = 81, 81
+    x = np.linspace(0, 1, Nx)
+    y = np.linspace(0, 1, Ny)
+    xx, yy = np.meshgrid(x, y, indexing="ij")
+    xy = np.stack([xx, yy], axis=-1)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        create_graph(graph_dir_path=tmpdir, xy=xy, n_max_levels=1)
+        g2m = torch.load(f"{tmpdir}/g2m_edge_index.pt")
+        assert (
+            g2m.shape[1] == 9009
+        ), f"Square grid g2m edges changed: expected 9009, got {g2m.shape[1]}"


### PR DESCRIPTION
## Describe your changes

`create_graph` previously generated square mesh graphs regardless of the data grid's physical aspect ratio, by passing the same value `n` for both x and y dimensions of `mk_2d_graph`. This caused two concrete problems, as stated in issue #371 :
1. Uneven mesh spacing: for a 200x30 domain (6.7:1 aspect ratio), the original 27x27 mesh packs y-nodes 6.7x more densely than x-nodes. This means the model sees different effective resolutions in each direction — weather features moving diagonally will appear different depending on their orientation relative to the mesh.
2. Redundant nodes: some of the rows of the smaller dimension in the original mesh cover the same grid points, wasting computation with no benefit to model accuracy.

**Changes:**
- At each mesh level, `n_x` and `n_y` are now derived independently by scaling the larger dimension proportionally to the physical 
  domain extent (`x_extent / y_extent`), assigning `n_larger` to whichever axis has greater physical extent.
- `mesh_dims` tracks `(n_x, n_y)` per level, replacing the square assumption in the merge loop reshape.
- `dm` is now computed from the mesh cell diagonal (`sqrt(dx**2 + dy**2)`) rather than x-direction spacing only. This would also guarantee full grid coverage with zero orphan node, which was a problem when migrating to a non square resolution.

No new dependencies.

## Issue Link

Closes #371 

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
