### PR TITLE
Visualize directed edge directions in plot_graph (#381)

### DIFF
--- a/neural_lam/create_graph.py
+++ b/neural_lam/create_graph.py
@@ -63,7 +63,7 @@ def plot_graph(graph, title=None):
                 start,
                 end,
                 arrowstyle="->",
-                mutation_scale=4.0,
+                mutation_scale=10.0,
                 linewidth=0.4,
                 color="black",
                 zorder=1,

--- a/neural_lam/create_graph.py
+++ b/neural_lam/create_graph.py
@@ -19,7 +19,56 @@ from .config import load_config_and_datastore
 from .datastore.base import BaseRegularGridDatastore
 
 
+def _median_nearest_neighbor_distance(pos: np.ndarray) -> float:
+    """Typical spacing between nodes in data units.
+
+    Used as one heuristic for arrow/node clearance in matplotlib data space.
+    """
+    n = pos.shape[0]
+    if n <= 1:
+        return 0.05
+    # Large graphs: subsample so KD-tree stays cheap
+    if n > 8000:
+        rng = np.random.default_rng(0)
+        idx = rng.choice(n, size=4000, replace=False)
+        p = pos[idx]
+    else:
+        p = pos
+    tree = scipy.spatial.cKDTree(p)
+    dists, _ = tree.query(p, k=2)
+    nn = dists[:, 1]
+    valid = nn > 1e-12
+    if not np.any(valid):
+        return 0.05
+    return float(np.median(nn[valid]))
+
+
+def _scatter_marker_radius_data(
+    axis, ref_xy: np.ndarray, s_points2: float
+) -> float:
+    """Approximate scatter marker radius in data units.
+
+    Matplotlib scatter uses area ``s`` in points^2. We convert to radius in pt
+    and map it to data units via the axis transforms so arrow trimming matches
+    visible markers (fix for arrowheads hiding underneath nodes).
+    """
+    if s_points2 <= 1e-12:
+        return 0.0
+    r_pt = float(np.sqrt(s_points2 / np.pi))
+    p0 = axis.transData.transform(ref_xy)
+    p1 = p0 + np.array([r_pt, 0.0], dtype=float)
+    ref1 = axis.transData.inverted().transform(p1)
+    return float(np.linalg.norm(ref1 - ref_xy))
+
+
 def plot_graph(graph, title=None):
+    """Plot a PyG ``Data`` object in 2D with directed/undirected edges.
+
+    Directed graphs use a single vectorised ``quiver`` call. Sizes/widths
+    scale with the number of nodes (N) and arrows are trimmed in data space
+    by an estimated node marker radius, so arrowheads don't get hidden under
+    node markers.
+    """
     fig, axis = plt.subplots(figsize=(8, 8), dpi=200)  # W,H
     edge_index = graph.edge_index
     pos = graph.pos
@@ -33,57 +82,120 @@ def plot_graph(graph, title=None):
         # Keep only 1 direction of edge_index
         edge_index = edge_index[:, edge_index[0] < edge_index[1]]  # (2, M/2)
 
-    # Move all to cpu and numpy, compute (in)-degrees
-    degrees = (
-        pyg.utils.degree(edge_index[1], num_nodes=pos.shape[0]).cpu().numpy()
-    )
+    # Degrees for node colouring (must match one-direction storage for undirected)
+    n_nodes_t = int(pos.shape[0])
+    if is_undirected:
+        degrees = (
+            pyg.utils.degree(edge_index[0], num_nodes=n_nodes_t)
+            + pyg.utils.degree(edge_index[1], num_nodes=n_nodes_t)
+        ).cpu().numpy()
+    else:
+        degrees = pyg.utils.degree(
+            edge_index[1], num_nodes=n_nodes_t
+        ).cpu().numpy()
+
     edge_index = edge_index.cpu().numpy()
     pos = pos.cpu().numpy()
+
+    n_nodes = int(pos.shape[0])
+    nn_dist = _median_nearest_neighbor_distance(pos)
+    span = float(
+        max(
+            np.ptp(pos[:, 0]),
+            np.ptp(pos[:, 1]),
+            1e-12,
+        )
+    )
 
     from_pos = pos[edge_index[0]]
     to_pos = pos[edge_index[1]]
 
+    inv_sqrt_n = 1.0 / max(np.sqrt(n_nodes), 1.0)
+
+    # Marker area (points^2): larger on small graphs; floor/clip for huge N
+    node_area = float(np.clip(240.0 * inv_sqrt_n, 12.0, 140.0))
+    marker_lw = float(np.clip(0.55 * inv_sqrt_n, 0.1, 0.45))
+
+    # Limits before quiver so transData matches final view (needed for marker-radius trimming).
+    pad = float(0.05 * span)
+    axis.set_xlim(float(pos[:, 0].min()) - pad, float(pos[:, 0].max()) + pad)
+    axis.set_ylim(float(pos[:, 1].min()) - pad, float(pos[:, 1].max()) + pad)
+
+    # Node "radius" in data units for trimming directed arrows
+    ref_xy = np.asarray(pos.mean(axis=0), dtype=float)
+    r_marker = _scatter_marker_radius_data(axis, ref_xy, node_area)
+    node_r_data = float(
+        max(1e-9, r_marker, 0.24 * nn_dist, 0.014 * span)
+    )
+
     if is_undirected:
-        # Plot undirected edges as simple line collection
         edge_lines = np.stack((from_pos, to_pos), axis=1)
+        line_w = float(np.clip(1.5 * inv_sqrt_n, 0.2, 2.4))
         axis.add_collection(
             matplotlib.collections.LineCollection(
-                edge_lines, lw=0.4, colors="black", zorder=1
+                edge_lines, lw=line_w, colors="black", zorder=1
             )
         )
     else:
-        # Plot directed edges as vectorised quiver arrows
-        dx = to_pos[:, 0] - from_pos[:, 0]
-        dy = to_pos[:, 1] - from_pos[:, 1]
-        valid = np.hypot(dx, dy) > 0
-        src = from_pos[valid]
-        dx, dy = dx[valid], dy[valid]
-        axis.quiver(
-            src[:, 0],
-            src[:, 1],
-            dx,
-            dy,
-            angles="xy",
-            scale_units="xy",
-            scale=1,
-            width=0.002,
-            color="black",
-            zorder=1,
-        )
+        # Vectorised quiver; trim both ends by ~node radius so heads clear markers.
+        vec = to_pos - from_pos
+        dist = np.hypot(vec[:, 0], vec[:, 1])
+        valid = dist > 1e-12
+
+        u = np.zeros_like(vec)
+        u[valid] = vec[valid] / dist[valid, np.newaxis]
+
+        trim_e = np.zeros_like(dist)
+        trim_e[valid] = np.minimum(node_r_data, 0.48 * dist[valid])
+
+        src = from_pos + u * trim_e[:, np.newaxis]
+        dst = to_pos - u * trim_e[:, np.newaxis]
+
+        dx = dst[:, 0] - src[:, 0]
+        dy = dst[:, 1] - src[:, 1]
+        ok = np.hypot(dx, dy) > 1e-12
+        dx, dy = dx[ok], dy[ok]
+        src_x, src_y = src[ok, 0], src[ok, 1]
+
+        # Quiver shaft/heads scaling: keep readable for small N and light for large N.
+        qwidth = float(np.clip(32.0 * inv_sqrt_n, 0.004, 0.024))
+        head_w = float(np.clip(4.5 - n_nodes / 3000.0, 2.6, 5.5))
+        head_l = float(np.clip(5.2 - n_nodes / 3000.0, 3.4, 6.2))
+
+        if dx.size > 0:
+            axis.quiver(
+                src_x,
+                src_y,
+                dx,
+                dy,
+                angles="xy",
+                scale_units="xy",
+                scale=1,
+                width=qwidth,
+                headwidth=head_w,
+                headlength=head_l,
+                headaxislength=head_l * 0.9,
+                color="black",
+                zorder=1,
+                pivot="tail",
+            )
 
     # Plot nodes
     node_scatter = axis.scatter(
         pos[:, 0],
         pos[:, 1],
         c=degrees,
-        s=3,
+        s=node_area,
         marker="o",
         zorder=2,
         cmap="viridis",
         clim=None,
+        edgecolors="face",
+        linewidths=marker_lw,
     )
 
     plt.colorbar(node_scatter, aspect=50)
+    axis.set_aspect("equal", adjustable="datalim")
 
     if title is not None:
         axis.set_title(title)

--- a/neural_lam/create_graph.py
+++ b/neural_lam/create_graph.py
@@ -21,7 +21,7 @@ from .datastore.base import BaseRegularGridDatastore
 
 def plot_graph(graph, title=None):
     fig, axis = plt.subplots(figsize=(8, 8), dpi=200)  # W,H
-    edge_index = graph.edge_index.clone()
+    edge_index = graph.edge_index
     pos = graph.pos
 
     # Fix for re-indexed edge indices only containing mesh nodes at
@@ -52,23 +52,24 @@ def plot_graph(graph, title=None):
             )
         )
     else:
-        # Plot directed edges with arrowheads
-        from matplotlib.patches import FancyArrowPatch
-
-        for start, end in zip(from_pos, to_pos):
-            # Skip degenerate edges
-            if np.allclose(start, end):
-                continue
-            arrow = FancyArrowPatch(
-                start,
-                end,
-                arrowstyle="->",
-                mutation_scale=10.0,
-                linewidth=0.4,
-                color="black",
-                zorder=1,
-            )
-            axis.add_patch(arrow)
+        # Plot directed edges as vectorised quiver arrows
+        dx = to_pos[:, 0] - from_pos[:, 0]
+        dy = to_pos[:, 1] - from_pos[:, 1]
+        valid = np.hypot(dx, dy) > 0
+        src = from_pos[valid]
+        dx, dy = dx[valid], dy[valid]
+        axis.quiver(
+            src[:, 0],
+            src[:, 1],
+            dx,
+            dy,
+            angles="xy",
+            scale_units="xy",
+            scale=1,
+            width=0.002,
+            color="black",
+            zorder=1,
+        )
 
     # Plot nodes
     node_scatter = axis.scatter(

--- a/neural_lam/create_graph.py
+++ b/neural_lam/create_graph.py
@@ -21,17 +21,17 @@ from .datastore.base import BaseRegularGridDatastore
 
 def plot_graph(graph, title=None):
     fig, axis = plt.subplots(figsize=(8, 8), dpi=200)  # W,H
-    edge_index = graph.edge_index
+    edge_index = graph.edge_index.clone()
     pos = graph.pos
 
     # Fix for re-indexed edge indices only containing mesh nodes at
     # higher levels in hierarchy
     edge_index = edge_index - edge_index.min()
 
-    if pyg.utils.is_undirected(edge_index):
+    is_undirected = pyg.utils.is_undirected(edge_index)
+    if is_undirected:
         # Keep only 1 direction of edge_index
         edge_index = edge_index[:, edge_index[0] < edge_index[1]]  # (2, M/2)
-    # TODO: indicate direction of directed edges
 
     # Move all to cpu and numpy, compute (in)-degrees
     degrees = (
@@ -40,15 +40,35 @@ def plot_graph(graph, title=None):
     edge_index = edge_index.cpu().numpy()
     pos = pos.cpu().numpy()
 
-    # Plot edges
-    from_pos = pos[edge_index[0]]  # (M/2, 2)
-    to_pos = pos[edge_index[1]]  # (M/2, 2)
-    edge_lines = np.stack((from_pos, to_pos), axis=1)
-    axis.add_collection(
-        matplotlib.collections.LineCollection(
-            edge_lines, lw=0.4, colors="black", zorder=1
+    from_pos = pos[edge_index[0]]
+    to_pos = pos[edge_index[1]]
+
+    if is_undirected:
+        # Plot undirected edges as simple line collection
+        edge_lines = np.stack((from_pos, to_pos), axis=1)
+        axis.add_collection(
+            matplotlib.collections.LineCollection(
+                edge_lines, lw=0.4, colors="black", zorder=1
+            )
         )
-    )
+    else:
+        # Plot directed edges with arrowheads
+        from matplotlib.patches import FancyArrowPatch
+
+        for start, end in zip(from_pos, to_pos):
+            # Skip degenerate edges
+            if np.allclose(start, end):
+                continue
+            arrow = FancyArrowPatch(
+                start,
+                end,
+                arrowstyle="->",
+                mutation_scale=4.0,
+                linewidth=0.4,
+                color="black",
+                zorder=1,
+            )
+            axis.add_patch(arrow)
 
     # Plot nodes
     node_scatter = axis.scatter(


### PR DESCRIPTION
## Describe your changes

- `plot_graph` now draws **undirected** graphs with `LineCollection` (unchanged behaviour).
- **Directed** graphs use **vectorised `quiver`** instead of per-edge patches (fast), with:
  - arrows **shortened** along each edge so heads are less likely to sit under scatter markers,
  - **width / headwidth / headlength** scaled from node count so tiny graphs stay readable and large ones stay light,
  - **`equal` aspect** so arrow geometry matches data space.
- Imports: `matplotlib.collections` at module level (no in-function imports for plotting).
- No `.clone()` on `edge_index` (unnecessary).

**Context:** Fixes misleading plots where directed edges looked undirected. Kept the implementation minimal because `create_graph` may move toward `weather-model-graphs` later.

**Research / correctness:**
- `neural_lam.plot_graph.plot_graph` (Plotly 3D) is **not** this function — `tests/test_plot_graph.py` imports that module; this PR only touches `create_graph.plot_graph` (matplotlib 2D).
- Undirected graphs stored as one edge orientation (`u < v`) now use **total degree** for node colours (`degree(src)+degree(dst)`), not only in-degree on `dst` (which skewed the colourbar).
- Directed case: skip `quiver` if no segments remain after dropping zero-length arrows (empty graph / degenerate edges).

**Dependencies:** None (same stack: matplotlib, PyG).

## Issue Link

Closes #381

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.








