### PR TITLE
Fix datastore config path resolution to support absolute paths

### DIFF
--- a/neural_lam/config.py
+++ b/neural_lam/config.py
@@ -181,8 +181,9 @@ def load_config_and_datastore(
     datastore_config_path = (
         Path(config_path).parent / config.datastore.config_path
     )
-    datastore = init_datastore(
-        datastore_kind=config.datastore.kind, config_path=datastore_config_path
-    )
+   datastore_config_path = Path(config.datastore.config_path)
+
+if not datastore_config_path.is_absolute():
+    datastore_config_path = Path(config_path).parent / datastore_config_path
 
     return config, datastore


### PR DESCRIPTION
The current implementation resolves the datastore configuration path by always appending `config.datastore.config_path` to the parent directory of the main configuration file:

    datastore_config_path = (
        Path(config_path).parent / config.datastore.config_path
    )

This assumes that `config.datastore.config_path` is always a relative path. If an absolute path is provided in the configuration file, this logic may lead to incorrect or unintended path resolution.

This patch improves robustness by first checking whether the path is absolute. If it is absolute, it is used directly; otherwise, it is resolved relative to the main configuration file.

Updated logic:

    datastore_config_path = Path(config.datastore.config_path)

    if not datastore_config_path.is_absolute():
        datastore_config_path = Path(config_path).parent / datastore_config_path

This ensures correct handling of both absolute and relative paths and improves configuration portability and reliability.

## Describe your changes

< Summary of the changes.>

< Please also include relevant motivation and context. >

< List any dependencies that are required for this change. >

## Issue Link

< Link to the relevant issue or task, if applicable > (e.g. `closes #00` or `solves #00`)

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
