### PR TITLE
docs: fix invalid pip install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ python -m pip install neural_lam
 1. Clone this repository and navigate to the root directory.
 > If you are happy using the latest version of `torch` with GPU support (expecting the latest version of CUDA is installed on your system) you can skip to step 3.
 2. Install a specific version of `torch` with `python -m pip install torch --index-url https://download.pytorch.org/whl/cpu` for a CPU-only version or `python -m pip install torch --index-url https://download.pytorch.org/whl/cu111` for CUDA 11.1 support (you can find the correct URL for the variant you want on [PyTorch webpage](https://pytorch.org/get-started/locally/)).
-3. Install the dependencies with `python -m pip install .`. If you will be developing `neural-lam` we recommend to install in editable mode and install the development dependencies with `python -m pip install --group dev -e .` so you can make changes to the code and see the effects immediately.
+3. Install the dependencies with `python -m pip install .`. If you will be developing `neural-lam` we recommend to install in editable mode and install the development dependencies with `python -m pip install -e ".[dev]"` so you can make changes to the code and see the effects immediately.
 
 
 # Using Neural-LAM


### PR DESCRIPTION
Hello Guys, I noticed a small typo error in the Using pip section of the README file. The instructions included says --group flag (python -m pip install --group dev -e.), Which is specific to uv and causes pip to throw a unrecognized option error. I've updated it to use the standard pip install -e ".[dev]" syntax so future contributors don't hit an installation crash.

Looking forward to contributing more to the project!
