### PR TITLE
Fix metrics_watch crash, test_step IndexError, and forcing DataArray AttributeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `AssertionError` crash in `aggregate_and_plot_metrics` when `--metrics_watch` is configured: scalar metric-watch values are now dispatched to `logger.log_metrics()` instead of being incorrectly asserted as `plt.Figure` objects. @RajdeepKushwaha5
+
+- Fix `IndexError` in `test_step` when `val_steps_to_log` contains steps beyond the prediction horizon: added the same bounds guard already present in `validation_step` to both the `test_log_dict` comprehension and the spatial-loss index list. @RajdeepKushwaha5
+
+- Fix `AttributeError` in `WeatherDataset.create_dataarray_from_tensor` for non-state categories (e.g. `forcing`): the method now uses the correct `{category}_feature` coordinate name instead of the hardcoded `state_feature`. @RajdeepKushwaha5
+
 - Initialize `da_forcing_mean` and `da_forcing_std` to `None` when forcing data is absent, fixing `AttributeError` in `WeatherDataset` with `standardize=True` [\#369](https://github.com/mllam/neural-lam/issues/369) @Sir-Sloth-The-Lazy
 
 - Ensure proper sorting of `analysis_time` in `NpyFilesDatastoreMEPS._get_analysis_times` independent of the order in which files are processed with glob [\#386](https://github.com/mllam/neural-lam/pull/386) @Gopisokk

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -155,6 +155,10 @@ class ARModel(pl.LightningModule):
 
         # For storing spatial loss maps during evaluation
         self.spatial_loss_maps: List[Any] = []
+        # The subset of val_steps_to_log that fall within the prediction
+        # horizon — computed on first test_step and used in on_test_epoch_end
+        # to correctly label spatial loss plots.
+        self.logged_spatial_steps: List[int] = []
 
         self.time_step_int, self.time_step_unit = get_integer_time(
             self._datastore.step_length
@@ -403,6 +407,7 @@ class ARModel(pl.LightningModule):
         test_log_dict = {
             f"test_loss_unroll{step}": time_step_loss[step - 1]
             for step in self.args.val_steps_to_log
+            if step <= len(time_step_loss)
         }
         test_log_dict["test_mean_loss"] = mean_loss
 
@@ -439,9 +444,17 @@ class ARModel(pl.LightningModule):
         spatial_loss = self.loss(
             prediction, target, pred_std, average_grid=False
         )  # (B, pred_steps, num_grid_nodes)
-        log_spatial_losses = spatial_loss[
-            :, [step - 1 for step in self.args.val_steps_to_log]
+        # Only keep steps that fit within the prediction horizon; store the
+        # filtered list so on_test_epoch_end can label plots correctly even
+        # when val_steps_to_log contains out-of-range values.
+        valid_steps = [
+            step
+            for step in self.args.val_steps_to_log
+            if step <= spatial_loss.shape[1]
         ]
+        if not self.logged_spatial_steps:
+            self.logged_spatial_steps = valid_steps
+        log_spatial_losses = spatial_loss[:, [s - 1 for s in valid_steps]]
         self.spatial_loss_maps.append(log_spatial_losses)
         # (B, N_log, num_grid_nodes)
 
@@ -665,26 +678,41 @@ class ARModel(pl.LightningModule):
                     )
                 )
 
-        # Ensure that log_dict has structure for
-        # logging as dict(str, plt.Figure)
-        assert all(
-            isinstance(key, str) and isinstance(value, plt.Figure)
-            for key, value in log_dict.items()
-        )
-
         if self.trainer.is_global_zero and not self.trainer.sanity_checking:
 
             current_epoch = self.trainer.current_epoch
+            scalar_log = {}
 
-            for key, figure in log_dict.items():
-                # For other loggers than wandb, add epoch to key.
-                # Wandb can log multiple images to the same key, while other
-                # loggers, such as MLFlow need unique keys for each image.
-                if not isinstance(self.logger, pl.loggers.WandbLogger):
-                    key = f"{key}-{current_epoch}"
+            for key, value in log_dict.items():
+                if isinstance(value, plt.Figure):
+                    # For other loggers than wandb, add epoch to key.
+                    # Wandb can log multiple images to the same key, while
+                    # other loggers, such as MLFlow need unique keys for each.
+                    log_key = (
+                        key
+                        if isinstance(self.logger, pl.loggers.WandbLogger)
+                        else f"{key}-{current_epoch}"
+                    )
+                    if hasattr(self.logger, "log_image"):
+                        self.logger.log_image(key=log_key, images=[value])
+                else:
+                    # Scalar metric from metrics_watch / var_leads_metrics_watch
+                    if isinstance(value, torch.Tensor):
+                        if value.ndim == 0:
+                            value_to_log = value.detach().cpu().item()
+                        else:
+                            warnings.warn(
+                                f"Skipping logging for non-scalar tensor "
+                                f"metric '{key}' with shape "
+                                f"{tuple(value.shape)}."
+                            )
+                            continue
+                    else:
+                        value_to_log = float(value)
+                    scalar_log[key] = value_to_log
 
-                if hasattr(self.logger, "log_image"):
-                    self.logger.log_image(key=key, images=[figure])
+            if scalar_log:
+                self.logger.log_metrics(scalar_log, step=current_epoch)
 
             plt.close("all")  # Close all figs
 
@@ -713,7 +741,7 @@ class ARModel(pl.LightningModule):
                     f"({(self.time_step_int * t_i)} {self.time_step_unit})",
                 )
                 for t_i, loss_map in zip(
-                    self.args.val_steps_to_log, mean_spatial_loss
+                    self.logged_spatial_steps, mean_spatial_loss
                 )
             ]
 
@@ -736,7 +764,7 @@ class ARModel(pl.LightningModule):
                 self.logger.save_dir, "spatial_loss_maps"
             )
             os.makedirs(pdf_loss_maps_dir, exist_ok=True)
-            for t_i, fig in zip(self.args.val_steps_to_log, pdf_loss_map_figs):
+            for t_i, fig in zip(self.logged_spatial_steps, pdf_loss_map_figs):
                 fig.savefig(os.path.join(pdf_loss_maps_dir, f"loss_t{t_i}.pdf"))
             # save mean spatial loss as .pt file also
             torch.save(
@@ -745,6 +773,7 @@ class ARModel(pl.LightningModule):
             )
 
         self.spatial_loss_maps.clear()
+        self.logged_spatial_steps.clear()
 
     def on_load_checkpoint(self, checkpoint):
         """

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -597,10 +597,10 @@ class WeatherDataset(torch.utils.data.Dataset):
 
         da_datastore_state = getattr(self, f"da_{category}")
         da_grid_index = da_datastore_state.grid_index
-        da_state_feature = da_datastore_state.state_feature
+        da_feature = da_datastore_state[f"{category}_feature"]
 
         coords = {
-            f"{category}_feature": da_state_feature,
+            f"{category}_feature": da_feature,
             "grid_index": da_grid_index,
         }
         if add_time_as_dim:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -329,3 +329,59 @@ def test_weather_dataset_no_forcing_standardize():
     assert (
         forcing.shape[-1] == 0
     ), "Expected zero forcing features when forcing is None"
+
+
+def test_create_dataarray_from_tensor_forcing_category():
+    """Regression test for Bug C: create_dataarray_from_tensor must work for
+    category='forcing', not just 'state'. Previously, the method hardcoded
+    ``da_datastore_state.state_feature`` for all categories, raising
+    AttributeError when category != 'state' because the forcing DataArray has
+    a 'forcing_feature' coordinate, not 'state_feature'.
+    """
+    # DummyDatastore has 2 forcing features
+    datastore = DummyDatastore(n_grid_points=100, n_timesteps=20)
+    n_grid = datastore.num_grid_points
+    n_forcing = len(datastore.get_vars_names("forcing"))
+
+    dataset = WeatherDataset(
+        datastore=datastore,
+        split="train",
+        ar_steps=3,
+    )
+
+    feature_names = datastore.get_vars_names("forcing")
+
+    # --- 2-D tensor: (grid_index, forcing_feature) ---
+    dummy_2d = torch.zeros(n_grid, n_forcing, dtype=torch.float32)
+    import datetime
+
+    t_single = DummyDatastore.T0
+    da_2d = dataset.create_dataarray_from_tensor(
+        tensor=dummy_2d,
+        time=t_single,
+        category="forcing",
+    )
+    assert da_2d.dims == (
+        "grid_index",
+        "forcing_feature",
+    ), f"Unexpected dims: {da_2d.dims}"
+    assert da_2d.shape == (n_grid, n_forcing)
+    np.testing.assert_array_equal(
+        da_2d["forcing_feature"].values, feature_names
+    )
+
+    # --- 3-D tensor: (time, grid_index, forcing_feature) ---
+    n_steps = 3
+    dummy_3d = torch.zeros(n_steps, n_grid, n_forcing, dtype=torch.float32)
+    times = [DummyDatastore.T0 + datetime.timedelta(hours=i) for i in range(n_steps)]
+    da_3d = dataset.create_dataarray_from_tensor(
+        tensor=dummy_3d,
+        time=times,
+        category="forcing",
+    )
+    assert da_3d.dims == (
+        "time",
+        "grid_index",
+        "forcing_feature",
+    ), f"Unexpected dims: {da_3d.dims}"
+    assert da_3d.shape == (n_steps, n_grid, n_forcing)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -124,3 +124,169 @@ def test_training(datastore_name):
 def test_training_output_std():
     datastore = init_datastore_example("mdp")  # Test only with mdp datastore
     run_simple_training(datastore, set_output_std=True)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for specific bug fixes that don't require a full training loop
+# ---------------------------------------------------------------------------
+
+
+def _build_model(datastore, val_steps_to_log, metrics_watch=None,
+                 var_leads_metrics_watch=None):
+    """
+    Instantiate a minimal GraphLAM on *datastore* without starting a trainer.
+    The graph directory is created if it does not already exist.
+    """
+    graph_name = "1level"
+    graph_dir_path = Path(datastore.root_path) / "graph" / graph_name
+    if not graph_dir_path.exists():
+        create_graph_from_datastore(
+            datastore=datastore,
+            output_root_path=str(graph_dir_path),
+            n_max_levels=1,
+        )
+
+    class ModelArgs:
+        output_std = False
+        loss = "mse"
+        restore_opt = False
+        n_example_pred = 0
+        graph = graph_name
+        hidden_dim = 4
+        hidden_layers = 1
+        processor_layers = 2
+        mesh_aggr = "sum"
+        lr = 1.0e-3
+        num_past_forcing_steps = 1
+        num_future_forcing_steps = 1
+
+    ModelArgs.val_steps_to_log = val_steps_to_log
+    ModelArgs.metrics_watch = metrics_watch or []
+    ModelArgs.var_leads_metrics_watch = var_leads_metrics_watch or {}
+
+    config = nlconfig.NeuralLAMConfig(
+        datastore=nlconfig.DatastoreSelection(
+            kind=datastore.SHORT_NAME, config_path=datastore.root_path
+        )
+    )
+    return GraphLAM(args=ModelArgs(), datastore=datastore, config=config)
+
+
+def test_create_metric_log_dict_with_metrics_watch():
+    """Regression test: aggregate_and_plot_metrics must not raise when
+    metrics_watch and var_leads_metrics_watch are configured, and must
+    dispatch figures to log_image() and scalars to log_metrics().
+
+    Before the fix, aggregate_and_plot_metrics had:
+        assert all(isinstance(value, plt.Figure) for _, value in log_dict.items())
+    which crashed as soon as a scalar was added for a watched variable.
+
+    This test drives aggregate_and_plot_metrics end-to-end with a stubbed
+    logger and verifies that log_image is called for Figure entries and
+    log_metrics is called for scalar entries without raising.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import matplotlib.pyplot as plt
+
+    datastore = init_datastore_example("dummydata")
+    n_state = datastore.get_num_data_vars("state")
+    pred_steps = 3
+
+    model = _build_model(
+        datastore,
+        val_steps_to_log=[1, 2, 3],
+        metrics_watch=["val_rmse"],
+        var_leads_metrics_watch={0: [1, 3]},
+    )
+
+    # Seed val_metrics with a synthetic batch of MSE values
+    model.val_metrics["mse"].append(
+        torch.ones(1, pred_steps, n_state, dtype=torch.float32)
+    )
+
+    # Stub trainer so that is_global_zero=True and sanity_checking=False
+    mock_trainer = MagicMock()
+    mock_trainer.is_global_zero = True
+    mock_trainer.sanity_checking = False
+    mock_trainer.current_epoch = 0
+
+    # Stub logger with inspectable log_image / log_metrics
+    class StubLogger:
+        def __init__(self):
+            self.log_image = MagicMock(name="log_image")
+            self.log_metrics = MagicMock(name="log_metrics")
+
+    stub_logger = StubLogger()
+    mock_trainer.logger = stub_logger
+    model._trainer = mock_trainer
+
+    # all_gather_cat is a no-op in single-process testing
+    model.all_gather_cat = lambda t: t
+
+    mock_fig = MagicMock(spec=plt.Figure)
+    with patch("neural_lam.vis.plot_error_map", return_value=mock_fig):
+        # Before the fix this raised AssertionError; now it must not
+        model.aggregate_and_plot_metrics(model.val_metrics, prefix="val")
+
+    assert stub_logger.log_image.called, (
+        "Expected log_image to be called for the error-map Figure"
+    )
+    assert stub_logger.log_metrics.called, (
+        "Expected log_metrics to be called for scalar watched-metric entries"
+    )
+
+
+def test_val_steps_to_log_guard_prevents_index_error():
+    """Regression test: test_step must not raise IndexError when
+    val_steps_to_log contains steps that exceed the prediction horizon, and
+    must only store spatial-loss maps for in-range steps.
+
+    validation_step already had this guard; test_step did not. The fix adds
+    the guard in two places: the test_log_dict dict-comprehension, and the
+    spatial-loss index list.
+
+    This test calls the real test_step with a mocked common_step so that
+    removing the guard from ar_model.py would cause this test to fail.
+    """
+    from unittest.mock import MagicMock
+
+    datastore = init_datastore_example("dummydata")
+    n_state = datastore.get_num_data_vars("state")
+    n_grid = datastore.num_grid_points
+    pred_steps = 3
+
+    model = _build_model(
+        datastore,
+        val_steps_to_log=[1, 2, 5, 10],  # steps 5 and 10 exceed the 3-step horizon
+    )
+
+    # Stub trainer — skip distributed gather and all plotting branches
+    mock_trainer = MagicMock()
+    mock_trainer.is_global_zero = False
+    model._trainer = mock_trainer
+
+    # log_dict requires a live trainer; stub it out
+    model.log_dict = MagicMock()
+
+    # Mock common_step to return well-shaped synthetic tensors
+    model.common_step = MagicMock(
+        return_value=(
+            torch.zeros(1, pred_steps, n_grid, n_state),  # prediction
+            torch.zeros(1, pred_steps, n_grid, n_state),  # target
+            model.per_var_std,  # pred_std (constant per-var std, shape (d_f,))
+            None,  # batch_times
+        )
+    )
+
+    # Must not raise IndexError
+    model.test_step(None, 0)
+
+    # Only steps 1 and 2 are within the 3-step horizon
+    assert len(model.spatial_loss_maps) == 1, (
+        "Expected exactly one spatial_loss_maps entry after one test step"
+    )
+    n_logged = model.spatial_loss_maps[0].shape[1]
+    assert n_logged == 2, (
+        f"Expected 2 in-range steps logged (1, 2), got {n_logged}"
+    )


### PR DESCRIPTION
## Describe your changes

Three independent bug fixes in `neural_lam/models/ar_model.py` and `neural_lam/weather_dataset.py`, each with a regression test.

**`AssertionError` crash when `--metrics_watch` is configured**

`create_metric_log_dict()` intentionally inserts scalar tensor values into `log_dict` alongside `plt.Figure` objects when `metrics_watch` / `var_leads_metrics_watch` are non-empty. The downstream `aggregate_and_plot_metrics()` then hit:

```python
assert all(isinstance(value, plt.Figure) for _, value in log_dict.items())
```

crashing before any metrics were logged. The fix removes the faulty assertion and dispatches on value type: figures go to `logger.log_image()`; scalars go to `logger.log_metrics()`.

**`IndexError` in `test_step` when `val_steps_to_log` exceeds the prediction horizon**

`validation_step` already guards against out-of-range steps with `if step <= len(time_step_loss)`, but `test_step` lacked this guard in two places: the `test_log_dict` dict-comprehension and the spatial-loss index list. Both are now guarded, matching `validation_step` behaviour.

**`AttributeError` in `create_dataarray_from_tensor` for non-state categories**

The method hardcoded `da_datastore_state.state_feature` regardless of the `category` argument. For `category='forcing'` the DataArray carries a `forcing_feature` coordinate, not `state_feature`, raising `AttributeError`. Fixed to `da_datastore_state[f"{category}_feature"]`.

No new dependencies.

## Issue Link

Closes #219
Closes #302
Closes #308

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form
- [ ] I have requested a reviewer and an assignee

## Checklist for reviewers

- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section reflecting type of change:

  **fixes**:
  - Fix `AssertionError` crash in `aggregate_and_plot_metrics` when `--metrics_watch` is configured: scalar metric-watch values are now dispatched to `logger.log_metrics()` instead of being incorrectly asserted as `plt.Figure` objects.
  - Fix `IndexError` in `test_step` when `val_steps_to_log` contains steps beyond the prediction horizon: added the same bounds guard already present in `validation_step` to both the `test_log_dict` comprehension and the spatial-loss index list.
  - Fix `AttributeError` in `WeatherDataset.create_dataarray_from_tensor` for non-state categories (e.g. `forcing`): the method now uses the correct `{category}_feature` coordinate name instead of the hardcoded `state_feature`.

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone
- [ ] author has added an entry to the changelog
- Once the PR is ready to be merged, squash commits and merge the PR.