### PR TITLE
feat(metrics): add spread_squared ensemble variance metric

### DIFF
--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -227,6 +227,65 @@ def crps_gauss(
     )
 
 
+def spread_squared(
+    pred, target, pred_std, mask=None, average_grid=True, sum_vars=True
+):
+    """
+    Ensemble variance (spread squared) metric.
+
+    Computes the unbiased sample variance of ensemble predictions across
+    the ensemble dimension (dim=-3). The entry-wise variance is then
+    passed through ``mask_and_reduce_metric`` for grid masking and
+    optional reduction — consistent with all other metrics.
+
+    This metric is used for spread-skill analysis: comparing ensemble
+    spread against forecast error (e.g. MSE) to assess probabilistic
+    calibration. For a well-calibrated ensemble, spread_squared should
+    approximate MSE.
+
+    (...,) is any number of batch dimensions
+    pred: (..., S, N, d_state), ensemble predictions where S is the
+        number of ensemble members at dim=-3
+    target: (..., N, d_state), target (unused, accepted for API
+        consistency with other metrics)
+    pred_std: (..., N, d_state) or (d_state,), predicted std.-dev.
+        (unused, accepted for API consistency)
+    mask: (N,), boolean mask describing which grid nodes to use
+    average_grid: boolean, if grid dimension -2 should be reduced
+        (mean over N)
+    sum_vars: boolean, if variable dimension -1 should be reduced
+        (sum over d_state)
+
+    Returns:
+    metric_val: One of (...,), (..., d_state), (..., N),
+        (..., N, d_state), depending on reduction arguments.
+    """
+    ens_dim = -3  # S dimension: pred is (..., S, N, d_state)
+    num_ens = pred.shape[ens_dim]
+    assert num_ens > 1, (
+        f"Ensemble variance requires more than 1 member, got S={num_ens}. "
+        "Single-member spread is undefined."
+    )
+
+    # Unbiased sample variance (Bessel's correction)
+    # var = (1/(S-1)) * sum((x_i - mean)^2)
+    # Implemented as: mean((x_i - mean)^2) * S/(S-1)
+    ens_mean = torch.mean(pred, dim=ens_dim)  # (..., N, d_state)
+    entry_spread = torch.mean(
+        (pred - ens_mean.unsqueeze(ens_dim)) ** 2,
+        dim=ens_dim,
+    ) * (
+        num_ens / (num_ens - 1)
+    )  # (..., N, d_state)
+
+    return mask_and_reduce_metric(
+        entry_spread,
+        mask=mask,
+        average_grid=average_grid,
+        sum_vars=sum_vars,
+    )
+
+
 DEFINED_METRICS = {
     "mse": mse,
     "mae": mae,
@@ -234,4 +293,5 @@ DEFINED_METRICS = {
     "wmae": wmae,
     "nll": nll,
     "crps_gauss": crps_gauss,
+    "spread_squared": spread_squared,
 }

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,252 @@
+"""
+Tests for spread_squared ensemble variance metric.
+
+Verifies:
+1. Mathematical correctness against known analytical values
+2. Unbiased estimation property (converges to true variance)
+3. Guard against single-member ensembles (S=1)
+4. Output shape matches the API contract
+5. Consistency with torch.var (Bessel-corrected)
+6. Correct behavior with mask and reduction flags
+
+Shape note: tests use (B, S, N, F) without an explicit T dimension.
+This is intentional — the metric follows the (..., S, N, d_state) convention
+where T (from Issue #335's (B, T, N, F) shape) is just another batch dim
+folded into (...). In ar_model.py, B and T are already flattened before
+metrics are called, so (B, S, N, F) accurately reflects real call shapes.
+"""
+
+# Third-party
+import pytest
+import torch
+
+# First-party
+from neural_lam.metrics import spread_squared
+
+
+class TestSpreadSquared:
+    """Tests for the spread_squared (ensemble variance) metric."""
+
+    def test_known_value_two_members(self):
+        """
+        For pred = [1.0, 3.0], unbiased variance = 2.0.
+        mean = 2.0, deviations = [-1, 1], sum of sq = 2, / (2-1) = 2.0
+        """
+        # Shape: (B=1, S=2, N=1, d_state=1)
+        # T is folded into B per the (...) convention
+        pred = torch.tensor([[[[1.0]], [[3.0]]]])
+        target = torch.zeros(1, 1, 1)  # (B, N, d_state) — unused
+        pred_std = torch.ones(1, 1, 1)  # unused
+
+        result = spread_squared(
+            pred,
+            target,
+            pred_std,
+            mask=None,
+            average_grid=False,
+            sum_vars=False,
+        )
+
+        # With average_grid=False, sum_vars=False → shape (B, N, d_state)
+        assert result.shape == (
+            1,
+            1,
+            1,
+        ), f"Expected shape (1,1,1), got {result.shape}"
+        assert torch.allclose(
+            result, torch.tensor([[[2.0]]])
+        ), f"Expected 2.0, got {result.item()}"
+
+    def test_known_value_three_members(self):
+        """
+        For pred = [2.0, 4.0, 6.0], mean=4.0,
+        unbiased var = ((2-4)^2 + (4-4)^2 + (6-4)^2) / (3-1) = 4.0.
+        """
+        # Shape: (B=1, S=3, N=1, d_state=1)
+        # T is folded into B per the (...) convention
+        pred = torch.tensor([[[[2.0]], [[4.0]], [[6.0]]]])
+        target = torch.zeros(1, 1, 1)
+        pred_std = torch.ones(1, 1, 1)
+
+        result = spread_squared(
+            pred,
+            target,
+            pred_std,
+            mask=None,
+            average_grid=False,
+            sum_vars=False,
+        )
+
+        assert torch.allclose(
+            result, torch.tensor([[[4.0]]])
+        ), f"Expected 4.0, got {result.item()}"
+
+    def test_unbiased_estimation_large_ensemble(self):
+        """
+        For a large ensemble drawn from N(0,1), the unbiased sample
+        variance should converge to the true variance (1.0).
+        """
+        torch.manual_seed(42)
+        S = 10000
+        # Shape: (B=1, S=10000, N=1, d_state=1)
+        # T is folded into B per the (...) convention
+        pred = torch.randn(1, S, 1, 1)
+        target = torch.zeros(1, 1, 1)
+        pred_std = torch.ones(1, 1, 1)
+
+        result = spread_squared(
+            pred,
+            target,
+            pred_std,
+            mask=None,
+            average_grid=False,
+            sum_vars=False,
+        )
+
+        assert (
+            torch.abs(result.squeeze() - 1.0) < 0.05
+        ), f"Expected ~1.0 for N(0,1) variance, got {result.item()}"
+
+    def test_rejects_single_member(self):
+        """S=1 must raise AssertionError — single-member variance
+        is undefined."""
+        pred = torch.randn(1, 1, 1, 1)  # S=1
+        target = torch.zeros(1, 1, 1)
+        pred_std = torch.ones(1, 1, 1)
+
+        with pytest.raises(AssertionError, match="more than 1 member"):
+            spread_squared(
+                pred,
+                target,
+                pred_std,
+                mask=None,
+                average_grid=False,
+                sum_vars=False,
+            )
+
+    def test_output_shape_no_reduction(self):
+        """
+        With average_grid=False, sum_vars=False, output shape should
+        be (..., N, d_state) with ensemble dim reduced.
+
+        T is a batch dimension folded into (...); pred is (B*T, S, N, F).
+        """
+        B, S, N, F = 4, 8, 100, 3
+        pred = torch.randn(B, S, N, F)  # (..., S, N, d_state)
+        target = torch.randn(B, N, F)
+        pred_std = torch.ones(F)
+
+        result = spread_squared(
+            pred,
+            target,
+            pred_std,
+            mask=None,
+            average_grid=False,
+            sum_vars=False,
+        )
+
+        # S reduced, rest preserved: (B, N, F)
+        assert result.shape == (
+            B,
+            N,
+            F,
+        ), f"Expected ({B},{N},{F}), got {result.shape}"
+
+    def test_output_shape_with_reduction(self):
+        """
+        With average_grid=True, sum_vars=True (defaults), output
+        should reduce N and d_state dims.
+
+        T is a batch dimension folded into (...); pred is (B*T, S, N, F).
+        """
+        B, S, N, F = 2, 5, 50, 4
+        pred = torch.randn(B, S, N, F)
+        target = torch.randn(B, N, F)
+        pred_std = torch.ones(F)
+
+        result = spread_squared(
+            pred,
+            target,
+            pred_std,
+            mask=None,
+            average_grid=True,
+            sum_vars=True,
+        )
+
+        # S reduced, N averaged, F summed: (B,)
+        assert result.shape == (B,), f"Expected ({B},), got {result.shape}"
+
+    def test_matches_torch_var(self):
+        """
+        Verify that spread_squared (without grid/var reduction) matches
+        torch.var with Bessel's correction across the ensemble dimension.
+        """
+        torch.manual_seed(123)
+        B, S, N, F = 2, 5, 10, 4
+        # T folded into B per (...) convention
+        pred = torch.randn(B, S, N, F)
+        target = torch.randn(B, N, F)
+        pred_std = torch.ones(F)
+
+        result = spread_squared(
+            pred,
+            target,
+            pred_std,
+            mask=None,
+            average_grid=False,
+            sum_vars=False,
+        )
+        # ens_dim=-3 means dim=1 for 4D input (B, S, N, F)
+        expected = torch.var(pred, dim=-3, unbiased=True)
+
+        assert torch.allclose(
+            result, expected, atol=1e-6
+        ), "spread_squared does not match torch.var(unbiased=True)"
+
+    def test_zero_spread(self):
+        """
+        If all ensemble members are identical, variance should be 0.
+        """
+        # Shape: (B=1, S=3, N=1, d_state=1) — all members = 5.0
+        pred = torch.full((1, 3, 1, 1), 5.0)
+        target = torch.zeros(1, 1, 1)
+        pred_std = torch.ones(1, 1, 1)
+
+        result = spread_squared(
+            pred,
+            target,
+            pred_std,
+            mask=None,
+            average_grid=False,
+            sum_vars=False,
+        )
+
+        assert torch.allclose(
+            result, torch.tensor([[[0.0]]])
+        ), f"Expected 0.0 for identical members, got {result.item()}"
+
+    def test_with_mask(self):
+        """
+        Verify that the boolean mask correctly filters grid nodes.
+        """
+        # Shape: (B=1, S=3, N=4, d_state=1)
+        pred = torch.randn(1, 3, 4, 1)
+        target = torch.randn(1, 4, 1)
+        pred_std = torch.ones(1)
+        mask = torch.tensor([True, False, True, False])  # keep 2 of 4 nodes
+
+        result = spread_squared(
+            pred,
+            target,
+            pred_std,
+            mask=mask,
+            average_grid=False,
+            sum_vars=False,
+        )
+
+        # N filtered from 4 to 2
+        assert result.shape == (
+            1,
+            2,
+            1,
+        ), f"Expected shape (1,2,1) with mask, got {result.shape}"


### PR DESCRIPTION
## Describe your changes

Add `spread_squared` (ensemble variance) metric to the metrics module.

This metric computes the unbiased sample variance across ensemble members, following the same API pattern as all existing metrics: `(pred, target, pred_std, mask, average_grid, sum_vars)`. Entry-wise variance is computed first across the ensemble dimension (dim=-3), then passed through `mask_and_reduce_metric` for grid masking and optional reduction.

**Key design decisions:**
- **Matches existing API**: Same signature as `mse`, `mae`, `nll`, etc. `target` and `pred_std` are accepted but unused, maintaining the uniform interface expected by `get_metric()` callers in `ar_model.py`.
- **`ens_dim = -3`**: Ensemble members are at the third-from-last dim, consistent with the (..., S, N,
   d_state) convention used throughout the metrics module. T from the (B, T, N, F) deterministic
  shape (#335) is a batch dim folded into (...) before calling metrics to match how `ar_model.py`
  already calls all other metrics in practice.
- **`assert S > 1`**: Single-member variance is undefined as
  discussed in #226 by @kshirajahere and @Panchadip-128
- **Bessel's correction**: Unbiased estimator (divides by S-1), consistent with the unbiased CRPS convention in @joeloskarsson's reference code shared in #226.
- **Internal `mask_and_reduce_metric` call**: Follows the same pattern as every other metric in the file.

This metric is a prerequisite for spread-skill analysis of ensemble and probabilistic models (Graph-EFM, Diffusion-LAM) tracked in #62.

**Dependencies:** None

## Issue Link

Addresses parts of #62
Related discussion: #226, #335

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.