### PR TITLE
Clear test_metrics in on_test_epoch_end for consistency with val_metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ This release introduces new features including GIF animation support, wandb run 
 
 ### Maintenance
 
+- Clear `test_metrics` lists in `on_test_epoch_end` for consistency with `val_metrics` clearing in `on_validation_epoch_end` [\#433](https://github.com/mllam/neural-lam/issues/433) [\#435](https://github.com/mllam/neural-lam/pull/435) @RajdeepKushwaha5
+
 - Update PR template to clarify milestone/roadmap requirement and maintenance changes [\#186](https://github.com/mllam/neural-lam/pull/186) @joeloskarsson
 
 - Update CI/CD to use python 3.13 for testing and full range of current python versions for linting (3.10 - 3.14) [\#173](https://github.com/mllam/neural-lam/pull/173) @observingClouds

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -824,6 +824,10 @@ class ARModel(pl.LightningModule):
         self.matched_metrics = set()
         self.spatial_loss_maps.clear()
 
+        # Clear lists with test metrics values
+        for metric_list in self.test_metrics.values():
+            metric_list.clear()
+
     def on_load_checkpoint(self, checkpoint):
         """
         Perform any changes to state dict before loading checkpoint

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,6 +1,8 @@
 # Standard library
+import tempfile
 import warnings
 from pathlib import Path
+from unittest.mock import patch
 
 # Third-party
 import pytest
@@ -201,3 +203,103 @@ def test_all_gather_cat_multi_device_simulation():
         "all_gather_cat produced incorrectly ordered/combined values "
         "on multi-device simulation"
     )
+
+
+def test_metrics_cleared_after_test_epoch():
+    """Test that test_metrics lists are cleared at the end of
+    on_test_epoch_end, consistent with how val_metrics are cleared in
+    on_validation_epoch_end. Runs trainer.test() twice on the same model
+    and verifies metrics don't accumulate across calls."""
+    datastore = init_datastore_example("dummydata")
+
+    device_name = "cpu"
+    graph_name = "1level"
+
+    graph_dir_path = Path(datastore.root_path) / "graph" / graph_name
+
+    if not graph_dir_path.exists():
+        create_graph_from_datastore(
+            datastore=datastore,
+            output_root_path=str(graph_dir_path),
+            n_max_levels=1,
+        )
+
+    data_module = WeatherDataModule(
+        datastore=datastore,
+        ar_steps_train=3,
+        ar_steps_eval=3,
+        standardize=True,
+        batch_size=2,
+        num_workers=1,
+        num_past_forcing_steps=1,
+        num_future_forcing_steps=1,
+    )
+
+    class ModelArgs:
+        output_std = False
+        loss = "mse"
+        restore_opt = False
+        n_example_pred = 0
+        graph = graph_name
+        hidden_dim = 4
+        hidden_layers = 1
+        processor_layers = 2
+        mesh_aggr = "sum"
+        lr = 1.0e-3
+        val_steps_to_log = [1, 3]
+        metrics_watch = []
+        num_past_forcing_steps = 1
+        num_future_forcing_steps = 1
+
+    config = nlconfig.NeuralLAMConfig(
+        datastore=nlconfig.DatastoreSelection(
+            kind=datastore.SHORT_NAME, config_path=datastore.root_path
+        )
+    )
+
+    model = GraphLAM(
+        args=ModelArgs(),
+        datastore=datastore,
+        config=config,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        trainer = pl.Trainer(
+            max_epochs=1,
+            deterministic=True,
+            accelerator=device_name,
+            devices=1,
+            log_every_n_steps=1,
+            logger=pl.loggers.CSVLogger(save_dir=tmp_dir),
+            enable_checkpointing=False,
+        )
+
+        # Patch all_gather_cat to work correctly on single device
+        # (without DDP, self.all_gather returns tensor unchanged, so
+        # .flatten(0,1) incorrectly collapses dims — see issue #421)
+        def _identity_gather(self, tensor_to_gather):
+            return tensor_to_gather
+
+        with patch.object(type(model), "all_gather_cat", _identity_gather):
+            # Run test twice on the same model instance
+            trainer.test(model=model, datamodule=data_module)
+            count_after_first = {
+                k: len(v) for k, v in model.test_metrics.items()
+            }
+
+            trainer.test(model=model, datamodule=data_module)
+            count_after_second = {
+                k: len(v) for k, v in model.test_metrics.items()
+            }
+
+    # After each test epoch, metrics should have been cleared.
+    # If the bug existed, counts after the second call would be double.
+    for metric_name in model.test_metrics:
+        assert count_after_first[metric_name] == 0, (
+            f"test_metrics['{metric_name}'] not cleared after first "
+            f"trainer.test(), has {count_after_first[metric_name]} entries"
+        )
+        assert count_after_second[metric_name] == 0, (
+            f"test_metrics['{metric_name}'] not cleared after second "
+            f"trainer.test(), has {count_after_second[metric_name]} entries"
+        )


### PR DESCRIPTION
### Describe your changes

`on_test_epoch_end` does not clear `test_metrics` after aggregation. This is inconsistent with `on_validation_epoch_end`, which clears `val_metrics`, and with `spatial_loss_maps`, which IS cleared in the same method.

This is a consistency improvement, not a bug fix — `trainer.test()` is only called once in normal usage. Adding the `.clear()` call aligns the test cleanup pattern with validation.

### Issue Link

closes #433

### Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)