### PR TITLE
Reset plotted_examples counter in on_test_epoch_end to restore example plotting across repeated test calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Close the `PIL.Image` file handle and delete the temporary `.png` after upload in `CustomMLFlowLogger.log_image`, fixing a resource leak and temp-file accumulation in CWD; replace `sys.exit(1)` on `NoCredentialsError` with a re-raise so callers can handle the failure [\#496](https://github.com/mllam/neural-lam/pull/496) @Zrahay
 
+- Reset `plotted_examples` and clear `test_metrics` at the end of `on_test_epoch_end` so repeated `trainer.test()` calls on the same model instance regenerate example plots and start from a clean metric slate instead of silently skipping plots and accumulating tensors [\#437](https://github.com/mllam/neural-lam/pull/437) @RajdeepKushwaha5
+
 ### Maintenance
 
 - Add comprehensive type hints to `neural_lam/metrics.py` [\#447](https://github.com/mllam/neural-lam/pull/447) @sidhantpande

--- a/neural_lam/models/module.py
+++ b/neural_lam/models/module.py
@@ -773,6 +773,18 @@ class ForecasterModule(pl.LightningModule):
         self.matched_metrics = set()
         self.spatial_loss_maps.clear()
 
+        # Clear stored test metrics so repeated `trainer.test()` calls on
+        # the same model instance start from a clean slate (otherwise the
+        # tensors accumulate and skew the aggregated metrics).
+        for metric_list in self.test_metrics.values():
+            metric_list.clear()
+
+        # Reset the example-plot counter so example prediction plots are
+        # generated again on every `trainer.test()` call, not just the
+        # first one (the guard `plotted_examples < n_example_pred` would
+        # otherwise stay permanently False).
+        self.plotted_examples = 0
+
     def on_load_checkpoint(self, checkpoint):
         loaded_state_dict = checkpoint["state_dict"]
 


### PR DESCRIPTION
## Describe your changes

`self.plotted_examples` in `ARModel` is initialized to `0` in `__init__` and incremented in `plot_examples`, but is **never reset** in `on_test_epoch_end` or any other hook.

After the first `trainer.test()` call, `plotted_examples >= n_example_pred` is permanently `True`, so the guard check:

```python
if (
    self.trainer.is_global_zero
    and self.plotted_examples < self.n_example_pred
):
```

…silently skips **all** example prediction plotting on any subsequent `trainer.test()` call on the same model instance.

**The fix:** Add `self.plotted_examples = 0` at the end of `on_test_epoch_end`, alongside the existing `self.spatial_loss_maps.clear()` call. This is consistent with how other per-epoch state (metrics, spatial loss maps) is already reset in the same method.

**Test:** Added `test_plotted_examples_reset_after_test_epoch` — an integration test that creates a real `GraphLAM` model with `DummyDatastore`, sets `n_example_pred=1`, runs `trainer.test()` twice on the same model instance, and asserts that `plotted_examples` is `0` after each call.

No dependencies required.

## Issue Link

closes #436

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [x] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [x] PR is up to date with the base branch
- [x] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.