### PR TITLE
docs: replace stale create_mesh references with create_graph in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ python -m neural_lam.datastore.npyfilesmeps.compute_standardization_stats <path-
 
 ### Graph creation
 
-Run `python -m neural_lam.create_mesh` with suitable options to generate the graph you want to use (see `python neural_lam.create_mesh --help` for a list of options).
+Run `python -m neural_lam.create_graph` with suitable options to generate the graph you want to use (see `python -m neural_lam.create_graph --help` for a list of options).
 The graphs used for the different models in the [paper](#graph-based-neural-weather-prediction-for-limited-area-modeling) can be created as:
 
 * **GC-LAM**: `python -m neural_lam.create_graph --config_path <neural-lam-config-path> --name multiscale`
@@ -530,13 +530,13 @@ The structure is shown with examples below:
 ```
 graphs
 ├── graph1                                  - Directory with a graph definition
-│   ├── m2m_edge_index.pt                   - Edges in mesh graph (neural_lam.create_mesh)
-│   ├── g2m_edge_index.pt                   - Edges from grid to mesh (neural_lam.create_mesh)
-│   ├── m2g_edge_index.pt                   - Edges from mesh to grid (neural_lam.create_mesh)
-│   ├── m2m_features.pt                     - Static features of mesh edges (neural_lam.create_mesh)
-│   ├── g2m_features.pt                     - Static features of grid to mesh edges (neural_lam.create_mesh)
-│   ├── m2g_features.pt                     - Static features of mesh to grid edges (neural_lam.create_mesh)
-│   └── mesh_features.pt                    - Static features of mesh nodes (neural_lam.create_mesh)
+│   ├── m2m_edge_index.pt                   - Edges in mesh graph (neural_lam.create_graph)
+│   ├── g2m_edge_index.pt                   - Edges from grid to mesh (neural_lam.create_graph)
+│   ├── m2g_edge_index.pt                   - Edges from mesh to grid (neural_lam.create_graph)
+│   ├── m2m_features.pt                     - Static features of mesh edges (neural_lam.create_graph)
+│   ├── g2m_features.pt                     - Static features of grid to mesh edges (neural_lam.create_graph)
+│   ├── m2g_features.pt                     - Static features of mesh to grid edges (neural_lam.create_graph)
+│   └── mesh_features.pt                    - Static features of mesh nodes (neural_lam.create_graph)
 ├── graph2
 ├── ...
 └── graphN
@@ -546,9 +546,9 @@ graphs
 To keep track of levels in the mesh graph, a list format is used for the files with mesh graph information.
 In particular, the files
 ```
-│   ├── m2m_edge_index.pt                   - Edges in mesh graph (neural_lam.create_mesh)
-│   ├── m2m_features.pt                     - Static features of mesh edges (neural_lam.create_mesh)
-│   ├── mesh_features.pt                    - Static features of mesh nodes (neural_lam.create_mesh)
+│   ├── m2m_edge_index.pt                   - Edges in mesh graph (neural_lam.create_graph)
+│   ├── m2m_features.pt                     - Static features of mesh edges (neural_lam.create_graph)
+│   ├── mesh_features.pt                    - Static features of mesh nodes (neural_lam.create_graph)
 ```
 all contain lists of length `L`, for a hierarchical mesh graph with `L` layers.
 For non-hierarchical graphs `L == 1` and these are all just singly-entry lists.
@@ -559,10 +559,10 @@ In addition, hierarchical mesh graphs (`L > 1`) feature a few additional files w
 ```
 ├── graph1
 │   ├── ...
-│   ├── mesh_down_edge_index.pt             - Downward edges in mesh graph (neural_lam.create_mesh)
-│   ├── mesh_up_edge_index.pt               - Upward edges in mesh graph (neural_lam.create_mesh)
-│   ├── mesh_down_features.pt               - Static features of downward mesh edges (neural_lam.create_mesh)
-│   ├── mesh_up_features.pt                 - Static features of upward mesh edges (neural_lam.create_mesh)
+│   ├── mesh_down_edge_index.pt             - Downward edges in mesh graph (neural_lam.create_graph)
+│   ├── mesh_up_edge_index.pt               - Upward edges in mesh graph (neural_lam.create_graph)
+│   ├── mesh_down_features.pt               - Static features of downward mesh edges (neural_lam.create_graph)
+│   ├── mesh_up_features.pt                 - Static features of upward mesh edges (neural_lam.create_graph)
 │   ├── ...
 ```
 These files have the same list format as the ones above, but each list has length `L-1` (as these edges describe connections between levels).


### PR DESCRIPTION
## Describe your changes

Replace all remaining `neural_lam.create_mesh` references in `README.md`
with `neural_lam.create_graph`.

`create_mesh` was renamed to `create_graph` in a prior refactor. The
example commands in the README were already updated but two locations
were missed:

- Introductory sentence in the "Graph creation" section (~L394)
- 14 file-tree comment annotations in the "Format of graph directory"
  section (both flat and hierarchical listings, ~L533–L565)

No dependencies required for this change.

## Issue Link

Closes #464

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the README to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form
- [ ] I have requested a reviewer and an assignee
```
- maintenance: correct stale create_mesh references to create_graph in README