### PR TITLE
docs: fix graph directory name in README (graphs/ -> graph/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ assume you placed `config.yaml` in a folder called `data`):
 data/
 ├── config.yaml           - Configuration file for neural-lam
 ├── danra.datastore.yaml  - Configuration file for the datastore, referred to from config.yaml
-└── graphs/               - Directory containing graphs for training
+└── graph/                - Directory containing graphs for training
 ```
 
 And the content of `config.yaml` could in this case look like:
@@ -398,7 +398,7 @@ The graphs used for the different models in the [paper](#graph-based-neural-weat
 * **Hi-LAM**: `python -m neural_lam.create_graph --config_path <neural-lam-config-path> --name hierarchical --hierarchical` (also works for Hi-LAM-Parallel)
 * **L1-LAM**: `python -m neural_lam.create_graph --config_path <neural-lam-config-path> --name 1level --levels 1`
 
-The graph-related files are stored in a directory called `graphs`.
+The graph-related files are stored in a directory called `graph`.
 
 ## Logging your experiments
 
@@ -525,10 +525,10 @@ Model classes, including abstract base classes, are located in `neural_lam/model
 Notebooks for visualization and analysis are located in `docs`.
 
 ## Format of graph directory
-The `graphs` directory contains generated graph structures that can be used by different graph-based models.
+The `graph` directory contains generated graph structures that can be used by different graph-based models.
 The structure is shown with examples below:
 ```
-graphs
+graph
 ├── graph1                                  - Directory with a graph definition
 │   ├── m2m_edge_index.pt                   - Edges in mesh graph (neural_lam.create_mesh)
 │   ├── g2m_edge_index.pt                   - Edges from grid to mesh (neural_lam.create_mesh)


### PR DESCRIPTION
## Describe your changes

Replace `graphs/` (plural) with `graph/` (singular) in three places in
README.md to match actual codebase behaviour:

- `README.md#L144` — folder structure example under "Using Neural-LAM"
- `README.md#L401` — "Graph creation" section prose  
- `README.md#L528` — "Format of graph directory" section heading and tree

The codebase consistently uses `graph/` (singular) across all relevant
files (`neural_lam/create_graph.py`, `neural_lam/models/base_graph_model.py`,
`neural_lam/plot_graph.py`, `tests/test_graph_creation.py`,
`tests/test_training.py`). The README was the only inconsistency.

No dependencies required for this change.

## Issue Link

Closes #465

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the README to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form
- [ ] I have requested a reviewer and an assignee
```
- fixes: correct graph directory name in README (graphs/ → graph/)