### PR TITLE
feat: add geometry utilities for global domains (spherical coords, area weights, KNN graph)

### DIFF
--- a/neural_lam/datastore/base.py
+++ b/neural_lam/datastore/base.py
@@ -630,3 +630,34 @@ class BaseRegularGridDatastore(BaseDatastore):
 
         """
         return self.grid_shape_state.x * self.grid_shape_state.y
+
+def get_area_weights(self) -> "xr.DataArray":
+    """Return latitude-based area weights for global domains.
+    
+    Returns:
+        DataArray of shape (grid_index,) with cos(lat) weights normalized
+        to have mean 1.0.
+    """
+    lat_lon = self.get_lat_lon()
+    # Extract latitude values (first element of stacked dim)
+    lat = lat_lon.isel(grid_index=0).lat.values
+    
+    from neural_lam.geometry import get_area_weights as compute_weights
+    weights = compute_weights(lat)
+    
+    import xarray as xr
+    return xr.DataArray(weights, dims=["grid_index"])
+
+def get_cartesian_coords(self) -> np.ndarray:
+    """Return cartesian coordinates on unit sphere.
+    
+    Returns:
+        Array of shape (grid_index, 3) with (x, y, z) coordinates
+        on the unit sphere.
+    """
+    lat_lon = self.get_lat_lon()
+    lon = lat_lon.isel(grid_index=0).lon.values
+    lat = lat_lon.isel(grid_index=0).lat.values
+    
+    from neural_lam.geometry import lat_lon_to_cartesian
+    return lat_lon_to_cartesian(lon, lat)

--- a/neural_lam/geometry.py
+++ b/neural_lam/geometry.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+def lat_lon_to_cartesian(lon: np.ndarray, lat: np.ndarray) -> np.ndarray:
+    """Convert (lon, lat) in degrees to (x, y, z) on unit sphere."""
+    lon_rad = np.radians(lon)
+    lat_rad = np.radians(lat)
+    x = np.cos(lat_rad) * np.cos(lon_rad)
+    y = np.cos(lat_rad) * np.sin(lon_rad)
+    z = np.sin(lat_rad)
+    return np.stack([x, y, z], axis=-1)
+
+def get_area_weights(lat: np.ndarray) -> np.ndarray:
+    """Return cos(latitude) weights normalized by mean weight."""
+    weights = np.cos(np.radians(lat))
+    return weights / weights.mean()

--- a/neural_lam/graph_builder.py
+++ b/neural_lam/graph_builder.py
@@ -1,0 +1,37 @@
+import numpy as np
+from typing import Tuple
+
+def build_spherical_knn_graph(
+    coords: np.ndarray,
+    k: int,
+    backend: str = "scipy",
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Build KNN graph on sphere using cartesian coordinates.
+    
+    Args:
+        coords: (N, 3) cartesian coordinates on unit sphere
+        k: Number of neighbors per node
+        backend: "scipy" (more backends to come)
+    
+    Returns:
+        edge_index: (2, E) adjacency list
+        edge_attr: (E,) distances
+    """
+    if backend == "scipy":
+        from scipy.spatial import KDTree
+        tree = KDTree(coords)
+        distances, indices = tree.query(coords, k=k+1)
+        
+        # Remove self-loop (first neighbor is self)
+        indices = indices[:, 1:]
+        distances = distances[:, 1:]
+        
+        n_nodes = len(coords)
+        src = np.repeat(np.arange(n_nodes), k)
+        dst = indices.flatten()
+        edge_index = np.stack([src, dst])
+        edge_attr = distances.flatten()
+        
+        return edge_index, edge_attr
+    else:
+        raise ValueError(f"Backend '{backend}' not implemented")


### PR DESCRIPTION
## Description of changes

This PR introduces foundational geometry utilities to support global forecasting capabilities. It adds spherical coordinate conversion, latitude-based area weights, and a modular KNN graph builder for global domains.

**Changes:**
- Adds `neural_lam/geometry.py`:
  - `lat_lon_to_cartesian()`: Converts (lon, lat) to (x, y, z) on a unit sphere  
  - `get_area_weights()`: Computes cos(latitude) weights normalized by the mean  
- Adds `neural_lam/graph_builder.py`:
  - `build_spherical_knn_graph()`: Backend-agnostic KNN graph construction on a sphere using Cartesian coordinates  
- Extends `BaseDatastore` in `neural_lam/datastores/base.py`:
  - `get_area_weights()`: Returns a DataArray of latitude-based weights  
  - `get_cartesian_coords()`: Returns an array of (x, y, z) coordinates  

**Motivation:**  
As part of global forecasting support (#63), reusable geometry utilities are required for area-weighted metrics and spherical graph construction. This PR establishes a modular geometry layer that future work can build upon.

**Dependencies:**  
This PR is designed to be standalone but will benefit from the `GlobalDummyDatastore` introduced in #444 for testing. Tests for global-specific functionality will be added after #444 is merged.

## Issue Link

Part of #63 (global forecasting support)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)  
- [x] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation (additions or improvements to documentation)  

## Checklist before requesting a review

- [x] My branch is up to date with the target branch (use `pull --rebase` if possible)  
- [x] I have performed a self-review of my code  
- [x] I have added docstrings for all new/modified functions and classes, clearly describing purpose, inputs, and outputs  
- [x] I have added inline comments where necessary to clarify complex logic  
- [ ] I have updated the [README](README.MD) to reflect these changes  
- [ ] I have added tests to validate the new functionality  
- [x] The PR title clearly describes the change and is written in imperative form  
- [ ] I have requested a reviewer and assigned the PR (if applicable)  