### PR TITLE
fix: make create_dataarray_from_tensor category-aware (Fixes #308)

### DIFF
--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -64,6 +64,9 @@ class WeatherDataset(torch.utils.data.Dataset):
         self.da_forcing = self.datastore.get_dataarray(
             category="forcing", split=self.split
         )
+        self.da_static = self.datastore.get_dataarray(
+            category="static", split=self.split
+        )
 
         # check that with the provided data-arrays and ar_steps that we have a
         # non-zero amount of samples
@@ -597,10 +600,11 @@ class WeatherDataset(torch.utils.data.Dataset):
 
         da_datastore_state = getattr(self, f"da_{category}")
         da_grid_index = da_datastore_state.grid_index
-        da_state_feature = da_datastore_state.state_feature
+        feature_name = f"{category}_feature"
+        da_feature = da_datastore_state.coords[feature_name]
 
         coords = {
-            f"{category}_feature": da_state_feature,
+            feature_name: da_feature,
             "grid_index": da_grid_index,
         }
         if add_time_as_dim:

--- a/tests/test_issue_308.py
+++ b/tests/test_issue_308.py
@@ -1,0 +1,56 @@
+# Standard library
+import datetime
+
+# Third-party
+import pytest
+import torch
+
+# First-party
+from neural_lam.weather_dataset import WeatherDataset
+from tests.conftest import init_datastore_example
+
+def test_create_dataarray_from_tensor_forcing():
+    """
+    Reproduce issue #308: create_dataarray_from_tensor fails for category="forcing"
+    """
+    datastore = init_datastore_example("dummydata")
+    dataset = WeatherDataset(datastore=datastore, split="train")
+    
+    # Get some forcing data
+    da_forcing = datastore.get_dataarray(category="forcing", split="train")
+    # Shape of forcing is (time, grid_index, forcing_feature)
+    forcing_tensor = torch.from_numpy(da_forcing.values).float()
+    times = da_forcing.time.values
+    
+    # This should work but currently fails with AttributeError: 'DataArray' object has no attribute 'state_feature'
+    da_forcing_new = dataset.create_dataarray_from_tensor(
+        tensor=forcing_tensor,
+        time=times,
+        category="forcing"
+    )
+    
+    assert da_forcing_new.dims == da_forcing.dims
+    assert "forcing_feature" in da_forcing_new.dims
+    assert "state_feature" not in da_forcing_new.dims
+
+def test_create_dataarray_from_tensor_static():
+    """
+    Check if it also works for static data
+    """
+    datastore = init_datastore_example("dummydata")
+    dataset = WeatherDataset(datastore=datastore, split="train")
+    
+    da_static = datastore.get_dataarray(category="static", split="train")
+    static_tensor = torch.from_numpy(da_static.values).float()
+    
+    # Static data doesn't have time dim usually, but create_dataarray_from_tensor 
+    # might expect one or handle its absence. 
+    # In WeatherDataset.py, it expects time if tensor is 2D (grid_index, feat)
+    
+    da_static_new = dataset.create_dataarray_from_tensor(
+        tensor=static_tensor,
+        time=datetime.datetime(2020, 1, 1), # Provide dummy time
+        category="static"
+    )
+    
+    assert "static_feature" in da_static_new.dims


### PR DESCRIPTION
## Describe your changes
This PR fixes a bug in `WeatherDataset.create_dataarray_from_tensor` where the `state_feature` coordinate was hardcoded, causing an `AttributeError` when trying to create DataArrays for `forcing` or `static` categories.

Key changes:
- Replaced hardcoded `.state_feature` with a dynamic lookup using `coords[f"{category}_feature"]`.
- Updated `WeatherDataset.__init__` to load `self.da_static` from the datastore, ensuring it is available for DataArray creation.
- Added a new regression test `tests/test_issue_308.py` covering both `forcing` and `static` categories.

## Issue Link
Fixes #308

## Type of change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review
- [x] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form.
