### PR TITLE
Fix get_integer_time precision and zero handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Close the `PIL.Image` file handle and delete the temporary `.png` after upload in `CustomMLFlowLogger.log_image`, fixing a resource leak and temp-file accumulation in CWD; replace `sys.exit(1)` on `NoCredentialsError` with a re-raise so callers can handle the failure [\#496](https://github.com/mllam/neural-lam/pull/496) @Zrahay
 
+- Refactor `get_integer_time` to use integer microsecond arithmetic instead of `total_seconds()` floats, with explicit handling for `timedelta(0)` (now returns `(0, 'seconds')` instead of `(0, 'weeks')`) and correct support for sub-second and negative timedeltas. Current callers all pass whole-hour `datastore.step_length` so behaviour is unchanged in practice; this is a defensive correctness improvement [\#494](https://github.com/mllam/neural-lam/pull/494) @Saptami191
+
 ### Maintenance
 
 - Add comprehensive type hints to `neural_lam/metrics.py` [\#447](https://github.com/mllam/neural-lam/pull/447) @sidhantpande

--- a/neural_lam/utils.py
+++ b/neural_lam/utils.py
@@ -654,22 +654,35 @@ def get_integer_time(tdelta: datetime.timedelta) -> tuple[int, str]:
     >>> get_integer_time(timedelta(milliseconds=1000))
     (1, 'seconds')
     >>> get_integer_time(timedelta(days=0.001))
-    (1, 'unknown')
+    (86400, 'milliseconds')
+    >>> get_integer_time(timedelta(0))
+    (0, 'seconds')
+    >>> get_integer_time(timedelta(days=-7))
+    (-1, 'weeks')
     """
-    total_seconds = tdelta.total_seconds()
+    # Use integer microseconds rather than tdelta.total_seconds() (a float)
+    # to avoid floating-point precision errors when checking divisibility.
+    total_microseconds = (
+        tdelta.days * 86400_000_000
+        + tdelta.seconds * 1_000_000
+        + tdelta.microseconds
+    )
+
+    if total_microseconds == 0:
+        return 0, "seconds"
 
     units = {
-        "weeks": 604800,
-        "days": 86400,
-        "hours": 3600,
-        "minutes": 60,
-        "seconds": 1,
-        "milliseconds": 0.001,
-        "microseconds": 0.000001,
+        "weeks": 604800_000_000,
+        "days": 86400_000_000,
+        "hours": 3600_000_000,
+        "minutes": 60_000_000,
+        "seconds": 1_000_000,
+        "milliseconds": 1_000,
+        "microseconds": 1,
     }
 
-    for unit, unit_in_seconds in units.items():
-        if total_seconds % unit_in_seconds == 0:
-            return int(total_seconds / unit_in_seconds), unit
+    for unit, unit_us in units.items():
+        if total_microseconds % unit_us == 0:
+            return total_microseconds // unit_us, unit
 
     return 1, "unknown"


### PR DESCRIPTION
## Describe your changes

Fix get_integer_time precision issues and zero timedelta handling.

Uses integer microseconds instead of float computation to avoid rounding errors and ensure correct unit detection.

No additional dependencies.

## Issue Link

Closes #468 

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form
- [ ] I have requested a reviewer and an assignee

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change:
  - fixes

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
