### PR TITLE
The Required Hirearchy added for the issue 49 in the models2

### DIFF
--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -227,6 +227,58 @@ def crps_gauss(
     )
 
 
+def crps_loss(
+    pred_ens, target, mask=None, average_grid=True, sum_vars=True
+):
+    """
+    Ensemble CRPS using the sample-based estimator.
+
+    Expects:
+    pred_ens: (B, S, T, N, d_state), ensemble predictions
+    target: (B, T, N, d_state), verifying truth
+    mask: (N,) or (N, 1), optional boolean/grid mask
+
+    Returns:
+    metric_val reduced according to average_grid/sum_vars after computing
+    CRPS entries with shape (B, T, N, d_state).
+    """
+    if pred_ens.dim() != 5:
+        raise ValueError("pred_ens must have shape (B, S, T, N, d_state)")
+    if target.dim() != 4:
+        raise ValueError("target must have shape (B, T, N, d_state)")
+    if pred_ens.shape[0] != target.shape[0]:
+        raise ValueError(
+            "Batch size mismatch between pred_ens and target in crps_loss"
+        )
+    if pred_ens.shape[2:] != target.shape[1:]:
+        raise ValueError(
+            "Shape mismatch: pred_ens (T,N,d_state) must match target "
+            "(T,N,d_state)"
+        )
+
+    if mask is not None:
+        if mask.dim() == 2:
+            mask = mask[:, 0]
+        mask = mask.to(torch.bool)
+
+    # E|X - y|
+    target_expanded = target.unsqueeze(1)  # (B, 1, T, N, d_state)
+    term_obs = torch.abs(pred_ens - target_expanded).mean(dim=1)
+    # (B, T, N, d_state)
+
+    # 0.5 * E|X - X'|
+    pairwise_abs = torch.abs(
+        pred_ens.unsqueeze(2) - pred_ens.unsqueeze(1)
+    )  # (B, S, S, T, N, d_state)
+    term_ens = 0.5 * pairwise_abs.mean(dim=(1, 2))
+    # (B, T, N, d_state)
+
+    entry_crps = term_obs - term_ens
+    return mask_and_reduce_metric(
+        entry_crps, mask=mask, average_grid=average_grid, sum_vars=sum_vars
+    )
+
+
 DEFINED_METRICS = {
     "mse": mse,
     "mae": mae,

--- a/neural_lam/models2/__init__.py
+++ b/neural_lam/models2/__init__.py
@@ -1,0 +1,12 @@
+# Local
+from .ar_forecaster import ARForecaster
+from .ar_forecast_sampler import ARForecastSampler
+from .base_graph_model import BaseGraphModel
+from .base_hi_graph_model import BaseHiGraphModel
+from .ensemble_forecaster_module import EnsembleForecasterModule
+from .forecaster import Forecaster
+from .forecaster_module import ForecasterModule
+from .graph_lam import GraphLAM
+from .hi_lam import HiLAM
+from .hi_lam_parallel import HiLAMParallel
+from .step_predictor import StepPredictor

--- a/neural_lam/models2/ar_forecast_sample.py
+++ b/neural_lam/models2/ar_forecast_sample.py
@@ -1,0 +1,4 @@
+# Local
+from .ar_forecast_sampler import ARForecastSampler
+
+__all__ = ["ARForecastSampler"]

--- a/neural_lam/models2/ar_forecast_sampler.py
+++ b/neural_lam/models2/ar_forecast_sampler.py
@@ -1,0 +1,133 @@
+# Third-party
+import torch
+
+# Local
+from .ar_forecaster import ARForecaster
+from .step_predictor import StepPredictor
+
+
+class ARForecastSampler(ARForecaster):
+    """
+    Ensemble sampler that perturbs initial states and delegates AR unroll.
+
+    This class creates stochastic ensemble members by adding Gaussian noise
+    to the expanded initial states and then calls ARForecaster on the expanded
+    batch as if it were a deterministic batch.
+    """
+
+    def __init__(
+        self,
+        step_predictor: StepPredictor,
+        args,
+        noise_std: float = 0.05,
+    ):
+        """
+        Parameters
+        ----------
+        step_predictor : StepPredictor
+            One-step predictor used by the AR unroll.
+        args : Any
+            Runtime args/config namespace.
+        noise_std : float
+            Standard deviation of Gaussian perturbations added to
+            `init_states` after ensemble expansion.
+        """
+        super().__init__(step_predictor, args)
+        self.noise_std = float(noise_std)
+
+    def forward(
+        self,
+        init_states: torch.Tensor,
+        forcing_features: torch.Tensor,
+        true_states: torch.Tensor = None,
+        pred_steps: int = None,
+        ensemble_size: int = 1,
+    ):
+        """
+        Generate ensemble forecasts by batch expansion and AR unroll.
+
+        Parameters
+        ----------
+        init_states : torch.Tensor
+            Shape (B, 2, N, F), where B=batch, 2=conditioning states,
+            N=grid nodes, F=state features.
+        forcing_features : torch.Tensor
+            Shape (B, T, N, F_forcing), where T=forecast horizon length.
+        true_states : torch.Tensor, optional
+            Boundary-condition source with shape (B, T, N, F) or
+            (B, S, T, N, F) when ensemble-specific boundaries are provided.
+        pred_steps : int, optional
+            Number of rollout steps; defaults to T from forcing_features.
+        ensemble_size : int
+            Number of ensemble members S.
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor | None]
+            prediction shape (B, S, T, N, F), and pred_std either
+            (B, S, T, N, F) when predicted by the model or a constant
+            per-variable tensor (F,) for deterministic predictors.
+        """
+        if ensemble_size < 2:
+            return super().forward(
+                init_states=init_states,
+                forcing_features=forcing_features,
+                true_states=true_states,
+                pred_steps=pred_steps,
+                ensemble_size=ensemble_size,
+            )
+
+        batch_size = init_states.shape[0]
+        max_steps = forcing_features.shape[1]
+        if pred_steps is None:
+            pred_steps = max_steps
+        if pred_steps > max_steps:
+            raise ValueError("pred_steps cannot exceed forcing time dimension")
+
+        # Expand batch to (B*S, ...)
+        expanded_init_states = init_states.repeat_interleave(
+            ensemble_size, dim=0
+        )
+        expanded_forcing = forcing_features[:, :pred_steps].repeat_interleave(
+            ensemble_size, dim=0
+        )
+
+        # Inject Gaussian perturbations to create ensemble diversity.
+        noise = torch.randn_like(expanded_init_states) * self.noise_std
+        expanded_init_states = expanded_init_states + noise
+
+        # Prepare boundary states to match the expanded batch if provided.
+        expanded_true_states = None
+        if true_states is not None:
+            if hasattr(self, "_prepare_true_states"):
+                expanded_true_states = self._prepare_true_states(
+                    true_states=true_states,
+                    batch_size=batch_size,
+                    pred_steps=pred_steps,
+                    ensemble_size=ensemble_size,
+                )
+            else:
+                expanded_true_states = true_states.repeat_interleave(
+                    ensemble_size, dim=0
+                )
+
+        # Trick: run parent forecaster with ensemble_size=1 on (B*S, ...).
+        prediction, pred_std = super().forward(
+            init_states=expanded_init_states,
+            forcing_features=expanded_forcing,
+            true_states=expanded_true_states,
+            pred_steps=pred_steps,
+            ensemble_size=1,
+        )  # prediction: (B*S, T, N, F)
+
+        # Reshape back to ensemble representation (B, S, T, N, F).
+        prediction = prediction.reshape(
+            batch_size, ensemble_size, pred_steps, *prediction.shape[2:]
+        )
+
+        if pred_std is not None and pred_std.ndim >= 4:
+            pred_std = pred_std.reshape(
+                batch_size, ensemble_size, pred_steps, *pred_std.shape[2:]
+            )
+
+        return prediction, pred_std

--- a/neural_lam/models2/ar_forecaster.py
+++ b/neural_lam/models2/ar_forecaster.py
@@ -1,0 +1,162 @@
+# Third-party
+import torch
+
+# Local
+from .forecaster import Forecaster
+from .step_predictor import StepPredictor
+
+
+class ARForecaster(Forecaster):
+    """
+    Auto-regressive forecaster that unrolls a StepPredictor in time.
+    """
+
+    def __init__(self, step_predictor: StepPredictor, args=None):
+        super().__init__()
+        self.step_predictor = step_predictor
+        self.args = args
+
+    def _prepare_true_states(
+        self,
+        true_states: torch.Tensor,
+        batch_size: int,
+        pred_steps: int,
+        ensemble_size: int,
+    ) -> torch.Tensor:
+        """
+        Prepare boundary states for AR unroll.
+
+        Accepts either:
+        - (B, T, N, d_f)
+        - (B, S, T, N, d_f)
+        """
+        if true_states.dim() == 4:
+            if true_states.shape[0] != batch_size:
+                raise ValueError(
+                    "true_states batch size must match init_states batch size"
+                )
+            if true_states.shape[1] < pred_steps:
+                raise ValueError(
+                    "true_states time dimension is smaller than pred_steps"
+                )
+            true_states = true_states[:, :pred_steps]
+            if ensemble_size > 1:
+                true_states = true_states.repeat_interleave(
+                    ensemble_size, dim=0
+                )
+            return true_states
+
+        if true_states.dim() == 5:
+            if true_states.shape[0] != batch_size:
+                raise ValueError(
+                    "true_states batch size must match init_states batch size"
+                )
+            if true_states.shape[1] != ensemble_size:
+                raise ValueError(
+                    "true_states ensemble dimension must match ensemble_size"
+                )
+            if true_states.shape[2] < pred_steps:
+                raise ValueError(
+                    "true_states time dimension is smaller than pred_steps"
+                )
+            true_states = true_states[:, :, :pred_steps]
+            return true_states.reshape(
+                batch_size * ensemble_size,
+                pred_steps,
+                *true_states.shape[3:],
+            )
+
+        raise ValueError(
+            "true_states must have shape (B,T,N,d_f) or (B,S,T,N,d_f)"
+        )
+
+    def forward(
+        self,
+        init_states: torch.Tensor,
+        forcing_features: torch.Tensor,
+        true_states: torch.Tensor = None,
+        pred_steps: int = None,
+        ensemble_size: int = 1,
+    ):
+        """
+        Roll out autoregressive prediction.
+
+        init_states: (B, 2, N, d_f)
+        forcing_features: (B, T, N, d_forcing)
+        true_states: (B, T, N, d_f) or (B, S, T, N, d_f)
+        """
+        if ensemble_size < 1:
+            raise ValueError("ensemble_size must be >= 1")
+
+        batch_size = init_states.shape[0]
+        max_steps = forcing_features.shape[1]
+        if pred_steps is None:
+            pred_steps = max_steps
+        if pred_steps > max_steps:
+            raise ValueError("pred_steps cannot exceed forcing time dimension")
+
+        # Trim forcing if caller requested a shorter unroll.
+        forcing_features = forcing_features[:, :pred_steps]
+
+        # Expand batch for ensemble execution.
+        if ensemble_size > 1:
+            init_states = init_states.repeat_interleave(ensemble_size, dim=0)
+            forcing_features = forcing_features.repeat_interleave(
+                ensemble_size, dim=0
+            )
+
+        if true_states is not None:
+            true_states = self._prepare_true_states(
+                true_states=true_states,
+                batch_size=batch_size,
+                pred_steps=pred_steps,
+                ensemble_size=ensemble_size,
+            )
+
+        prev_prev_state = init_states[:, 0]
+        prev_state = init_states[:, 1]
+        prediction_list = []
+        pred_std_list = []
+
+        for step_idx in range(pred_steps):
+            forcing = forcing_features[:, step_idx]
+
+            pred_state, pred_std = self.step_predictor.predict_step(
+                prev_state, prev_prev_state, forcing
+            )
+
+            # Match ARModel behavior: overwrite boundary with truth when given.
+            if true_states is not None:
+                border_state = true_states[:, step_idx]
+                new_state = (
+                    self.step_predictor.boundary_mask * border_state
+                    + self.step_predictor.interior_mask * pred_state
+                )
+            else:
+                new_state = pred_state
+
+            prediction_list.append(new_state)
+            if self.step_predictor.output_std:
+                pred_std_list.append(pred_std)
+
+            prev_prev_state = prev_state
+            prev_state = new_state
+
+        prediction = torch.stack(prediction_list, dim=1)
+        if self.step_predictor.output_std:
+            pred_std = torch.stack(pred_std_list, dim=1)
+        else:
+            # Keep ARModel contract: use constant per-variable std if model
+            # does not predict std directly.
+            pred_std = self.step_predictor.per_var_std
+
+        if ensemble_size > 1:
+            prediction = prediction.reshape(
+                batch_size, ensemble_size, pred_steps, *prediction.shape[2:]
+            )
+            if self.step_predictor.output_std:
+                pred_std = pred_std.reshape(
+                    batch_size, ensemble_size, pred_steps, *pred_std.shape[2:]
+                )
+
+        return prediction, pred_std

--- a/neural_lam/models2/base_graph_model.py
+++ b/neural_lam/models2/base_graph_model.py
@@ -1,0 +1,365 @@
+# Third-party
+import torch
+
+# Local
+from .. import utils
+from ..config import NeuralLAMConfig
+from ..datastore import BaseDatastore
+from ..interaction_net import InteractionNet
+from .step_predictor import StepPredictor
+
+
+class BaseGraphModel(StepPredictor):
+    """
+    Base (abstract) class for graph-based models building on
+    the encode-process-decode idea.
+    """
+
+    def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
+        super().__init__(args, config=config, datastore=datastore)
+
+        # Load graph with static features
+        # NOTE: (IMPORTANT!) mesh nodes MUST have the first
+        # num_mesh_nodes indices,
+        graph_dir_path = datastore.root_path / "graph" / args.graph
+        self.hierarchical, graph_ldict = utils.load_graph(
+            graph_dir_path=graph_dir_path
+        )
+        for name, attr_value in graph_ldict.items():
+            # Make BufferLists module members and register tensors as buffers
+            if isinstance(attr_value, torch.Tensor):
+                self.register_buffer(name, attr_value, persistent=False)
+            else:
+                setattr(self, name, attr_value)
+
+        # Specify dimensions of data
+        self.num_mesh_nodes, _ = self.get_num_mesh()
+        utils.log_on_rank_zero(
+            f"Loaded graph with {self.num_grid_nodes + self.num_mesh_nodes} "
+            f"nodes ({self.num_grid_nodes} grid, {self.num_mesh_nodes} mesh)"
+        )
+
+        # grid_dim from data + static
+        self.g2m_edges, g2m_dim = self.g2m_features.shape
+        self.m2g_edges, m2g_dim = self.m2g_features.shape
+
+        # Define sub-models
+        # Feature embedders for grid
+        self.mlp_blueprint_end = [args.hidden_dim] * (args.hidden_layers + 1)
+        self.grid_embedder = utils.make_mlp(
+            [self.grid_dim] + self.mlp_blueprint_end
+        )
+        self.g2m_embedder = utils.make_mlp([g2m_dim] + self.mlp_blueprint_end)
+        self.m2g_embedder = utils.make_mlp([m2g_dim] + self.mlp_blueprint_end)
+
+        # GNNs
+        # encoder
+        self.g2m_gnn = InteractionNet(
+            self.g2m_edge_index,
+            args.hidden_dim,
+            hidden_layers=args.hidden_layers,
+            update_edges=False,
+        )
+        self.encoding_grid_mlp = utils.make_mlp(
+            [args.hidden_dim] + self.mlp_blueprint_end
+        )
+
+        # decoder
+        self.m2g_gnn = InteractionNet(
+            self.m2g_edge_index,
+            args.hidden_dim,
+            hidden_layers=args.hidden_layers,
+            update_edges=False,
+        )
+
+        # Output mapping (hidden_dim -> output_dim)
+        self.output_map = utils.make_mlp(
+            [args.hidden_dim] * (args.hidden_layers + 1)
+            + [self.grid_output_dim],
+            layer_norm=False,
+        )  # No layer norm on this one
+
+        # Compute indices and define clamping functions
+        self.prepare_clamping_params(config, datastore)
+
+    def prepare_clamping_params(
+        self, config: NeuralLAMConfig, datastore: BaseDatastore
+    ):
+        """
+        Prepare parameters for clamping predicted values to valid range
+        """
+
+        # Read configs
+        state_feature_names = datastore.get_vars_names(category="state")
+        lower_lims = config.training.output_clamping.lower
+        upper_lims = config.training.output_clamping.upper
+
+        # Check that limits in config are for valid features
+        unknown_features_lower = set(lower_lims.keys()) - set(
+            state_feature_names
+        )
+        unknown_features_upper = set(upper_lims.keys()) - set(
+            state_feature_names
+        )
+        if unknown_features_lower or unknown_features_upper:
+            raise ValueError(
+                "State feature limits were provided for unknown features: "
+                f"{unknown_features_lower.union(unknown_features_upper)}"
+            )
+
+        # Constant parameters for clamping
+        sigmoid_sharpness = 1
+        softplus_sharpness = 1
+        sigmoid_center = 0
+        softplus_center = 0
+
+        normalize_clamping_lim = (
+            lambda x, feature_idx: (x - self.state_mean[feature_idx])
+            / self.state_std[feature_idx]
+        )
+
+        # Check which clamping functions to use for each feature
+        sigmoid_lower_upper_idx = []
+        sigmoid_lower_lims = []
+        sigmoid_upper_lims = []
+
+        softplus_lower_idx = []
+        softplus_lower_lims = []
+
+        softplus_upper_idx = []
+        softplus_upper_lims = []
+
+        for feature_idx, feature in enumerate(state_feature_names):
+            if feature in lower_lims and feature in upper_lims:
+                assert (
+                    lower_lims[feature] < upper_lims[feature]
+                ), f'Invalid clamping limits for feature "{feature}",\
+                     lower: {lower_lims[feature]}, larger than\
+                     upper: {upper_lims[feature]}'
+                sigmoid_lower_upper_idx.append(feature_idx)
+                sigmoid_lower_lims.append(
+                    normalize_clamping_lim(lower_lims[feature], feature_idx)
+                )
+                sigmoid_upper_lims.append(
+                    normalize_clamping_lim(upper_lims[feature], feature_idx)
+                )
+            elif feature in lower_lims and feature not in upper_lims:
+                softplus_lower_idx.append(feature_idx)
+                softplus_lower_lims.append(
+                    normalize_clamping_lim(lower_lims[feature], feature_idx)
+                )
+            elif feature not in lower_lims and feature in upper_lims:
+                softplus_upper_idx.append(feature_idx)
+                softplus_upper_lims.append(
+                    normalize_clamping_lim(upper_lims[feature], feature_idx)
+                )
+
+        self.register_buffer(
+            "sigmoid_lower_lims", torch.tensor(sigmoid_lower_lims)
+        )
+        self.register_buffer(
+            "sigmoid_upper_lims", torch.tensor(sigmoid_upper_lims)
+        )
+        self.register_buffer(
+            "softplus_lower_lims", torch.tensor(softplus_lower_lims)
+        )
+        self.register_buffer(
+            "softplus_upper_lims", torch.tensor(softplus_upper_lims)
+        )
+
+        self.register_buffer(
+            "clamp_lower_upper_idx", torch.tensor(sigmoid_lower_upper_idx)
+        )
+        self.register_buffer(
+            "clamp_lower_idx", torch.tensor(softplus_lower_idx)
+        )
+        self.register_buffer(
+            "clamp_upper_idx", torch.tensor(softplus_upper_idx)
+        )
+
+        # Define clamping functions
+        self.clamp_lower_upper = lambda x: (
+            self.sigmoid_lower_lims
+            + (self.sigmoid_upper_lims - self.sigmoid_lower_lims)
+            * torch.sigmoid(sigmoid_sharpness * (x - sigmoid_center))
+        )
+        self.clamp_lower = lambda x: (
+            self.softplus_lower_lims
+            + torch.nn.functional.softplus(
+                x - softplus_center, beta=softplus_sharpness
+            )
+        )
+        self.clamp_upper = lambda x: (
+            self.softplus_upper_lims
+            - torch.nn.functional.softplus(
+                softplus_center - x, beta=softplus_sharpness
+            )
+        )
+
+        self.inverse_clamp_lower_upper = lambda x: (
+            sigmoid_center
+            + utils.inverse_sigmoid(
+                (x - self.sigmoid_lower_lims)
+                / (self.sigmoid_upper_lims - self.sigmoid_lower_lims)
+            )
+            / sigmoid_sharpness
+        )
+        self.inverse_clamp_lower = lambda x: (
+            utils.inverse_softplus(
+                x - self.softplus_lower_lims, beta=softplus_sharpness
+            )
+            + softplus_center
+        )
+        self.inverse_clamp_upper = lambda x: (
+            -utils.inverse_softplus(
+                self.softplus_upper_lims - x, beta=softplus_sharpness
+            )
+            + softplus_center
+        )
+
+    def get_clamped_new_state(self, state_delta, prev_state):
+        """
+        Clamp prediction to valid range supplied in config
+        Returns the clamped new state after adding delta to original state
+
+        Instead of the new state being computed as
+        $X_{t+1} = X_t + \\delta = X_t + model(\\{X_t,X_{t-1},...\\}, forcing)$
+        The clamped values will be
+        $f(f^{-1}(X_t) + model(\\{X_t, X_{t-1},... \\}, forcing))$
+        Which means the model will learn to output values in the range of the
+        inverse clamping function
+
+        state_delta: (B, num_grid_nodes, feature_dim)
+        prev_state: (B, num_grid_nodes, feature_dim)
+        """
+
+        # Assign new state, but overwrite clamped values of each type later
+        new_state = prev_state + state_delta
+
+        # Sigmoid/logistic clamps between ]a,b[
+        if self.clamp_lower_upper_idx.numel() > 0:
+            idx = self.clamp_lower_upper_idx
+
+            new_state[:, :, idx] = self.clamp_lower_upper(
+                self.inverse_clamp_lower_upper(prev_state[:, :, idx])
+                + state_delta[:, :, idx]
+            )
+
+        # Softplus clamps between ]a,infty[
+        if self.clamp_lower_idx.numel() > 0:
+            idx = self.clamp_lower_idx
+
+            new_state[:, :, idx] = self.clamp_lower(
+                self.inverse_clamp_lower(prev_state[:, :, idx])
+                + state_delta[:, :, idx]
+            )
+
+        # Softplus clamps between ]-infty,b[
+        if self.clamp_upper_idx.numel() > 0:
+            idx = self.clamp_upper_idx
+
+            new_state[:, :, idx] = self.clamp_upper(
+                self.inverse_clamp_upper(prev_state[:, :, idx])
+                + state_delta[:, :, idx]
+            )
+
+        return new_state
+
+    def get_num_mesh(self):
+        """
+        Compute number of mesh nodes from loaded features,
+        and number of mesh nodes that should be ignored in encoding/decoding
+        """
+        raise NotImplementedError("get_num_mesh not implemented")
+
+    def embedd_mesh_nodes(self):
+        """
+        Embed static mesh features
+        Returns tensor of shape (num_mesh_nodes, d_h)
+        """
+        raise NotImplementedError("embedd_mesh_nodes not implemented")
+
+    def process_step(self, mesh_rep):
+        """
+        Process step of embedd-process-decode framework
+        Processes the representation on the mesh, possible in multiple steps
+
+        mesh_rep: has shape (B, num_mesh_nodes, d_h)
+        Returns mesh_rep: (B, num_mesh_nodes, d_h)
+        """
+        raise NotImplementedError("process_step not implemented")
+
+    def predict_step(self, prev_state, prev_prev_state, forcing):
+        """
+        Step state one step ahead using prediction model, X_{t-1}, X_t -> X_t+1
+        prev_state: (B, num_grid_nodes, feature_dim), X_t
+        prev_prev_state: (B, num_grid_nodes, feature_dim), X_{t-1}
+        forcing: (B, num_grid_nodes, forcing_dim)
+        """
+        batch_size = prev_state.shape[0]
+
+        # Create full grid node features of shape (B, num_grid_nodes, grid_dim)
+        grid_features = torch.cat(
+            (
+                prev_state,
+                prev_prev_state,
+                forcing,
+                self.expand_to_batch(self.grid_static_features, batch_size),
+            ),
+            dim=-1,
+        )
+
+        # Embed all features
+        grid_emb = self.grid_embedder(grid_features)  # (B, num_grid_nodes, d_h)
+        g2m_emb = self.g2m_embedder(self.g2m_features)  # (M_g2m, d_h)
+        m2g_emb = self.m2g_embedder(self.m2g_features)  # (M_m2g, d_h)
+        mesh_emb = self.embedd_mesh_nodes()
+
+        # Map from grid to mesh
+        mesh_emb_expanded = self.expand_to_batch(
+            mesh_emb, batch_size
+        )  # (B, num_mesh_nodes, d_h)
+        g2m_emb_expanded = self.expand_to_batch(g2m_emb, batch_size)
+
+        # This also splits representation into grid and mesh
+        mesh_rep = self.g2m_gnn(
+            grid_emb, mesh_emb_expanded, g2m_emb_expanded
+        )  # (B, num_mesh_nodes, d_h)
+        # Also MLP with residual for grid representation
+        grid_rep = grid_emb + self.encoding_grid_mlp(
+            grid_emb
+        )  # (B, num_grid_nodes, d_h)
+
+        # Run processor step
+        mesh_rep = self.process_step(mesh_rep)
+
+        # Map back from mesh to grid
+        m2g_emb_expanded = self.expand_to_batch(m2g_emb, batch_size)
+        grid_rep = self.m2g_gnn(
+            mesh_rep, grid_rep, m2g_emb_expanded
+        )  # (B, num_grid_nodes, d_h)
+
+        # Map to output dimension, only for grid
+        net_output = self.output_map(
+            grid_rep
+        )  # (B, num_grid_nodes, d_grid_out)
+
+        if self.output_std:
+            pred_delta_mean, pred_std_raw = net_output.chunk(
+                2, dim=-1
+            )  # both (B, num_grid_nodes, d_f)
+            # NOTE: The predicted std. is not scaled in any way here
+            # linter for some reason does not think softplus is callable
+            # pylint: disable-next=not-callable
+            pred_std = torch.nn.functional.softplus(pred_std_raw)
+        else:
+            pred_delta_mean = net_output
+            pred_std = None
+
+        # Rescale with one-step difference statistics
+        rescaled_delta_mean = pred_delta_mean * self.diff_std + self.diff_mean
+
+        # Clamp values to valid range (also add the delta to the previous state)
+        new_state = self.get_clamped_new_state(rescaled_delta_mean, prev_state)
+
+        return new_state, pred_std

--- a/neural_lam/models2/base_hi_graph_model.py
+++ b/neural_lam/models2/base_hi_graph_model.py
@@ -1,0 +1,237 @@
+# Third-party
+from torch import nn
+
+# Local
+from .. import utils
+from ..config import NeuralLAMConfig
+from ..datastore import BaseDatastore
+from ..interaction_net import InteractionNet
+from .base_graph_model import BaseGraphModel
+
+
+class BaseHiGraphModel(BaseGraphModel):
+    """
+    Base class for hierarchical graph models.
+    """
+
+    def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
+        super().__init__(args, config=config, datastore=datastore)
+
+        # Track number of nodes, edges on each level
+        # Flatten lists for efficient embedding
+        self.num_levels = len(self.mesh_static_features)
+
+        # Number of mesh nodes at each level
+        self.level_mesh_sizes = [
+            mesh_feat.shape[0] for mesh_feat in self.mesh_static_features
+        ]  # Needs as python list for later
+
+        # Print some useful info
+        utils.log_on_rank_zero("Loaded hierarchical graph with structure:")
+        for level_index, level_mesh_size in enumerate(self.level_mesh_sizes):
+            same_level_edges = self.m2m_features[level_index].shape[0]
+            utils.log_on_rank_zero(
+                f"level {level_index} - {level_mesh_size} nodes, "
+                f"{same_level_edges} same-level edges"
+            )
+
+            if level_index < (self.num_levels - 1):
+                up_edges = self.mesh_up_features[level_index].shape[0]
+                down_edges = self.mesh_down_features[level_index].shape[0]
+                utils.log_on_rank_zero(f"  {level_index}<->{level_index + 1}")
+                utils.log_on_rank_zero(
+                    f" - {up_edges} up edges, {down_edges} down edges"
+                )
+        # Embedders
+        # Assume all levels have same static feature dimensionality
+        mesh_dim = self.mesh_static_features[0].shape[1]
+        mesh_same_dim = self.m2m_features[0].shape[1]
+        mesh_up_dim = self.mesh_up_features[0].shape[1]
+        mesh_down_dim = self.mesh_down_features[0].shape[1]
+
+        # Separate mesh node embedders for each level
+        self.mesh_embedders = nn.ModuleList(
+            [
+                utils.make_mlp([mesh_dim] + self.mlp_blueprint_end)
+                for _ in range(self.num_levels)
+            ]
+        )
+        self.mesh_same_embedders = nn.ModuleList(
+            [
+                utils.make_mlp([mesh_same_dim] + self.mlp_blueprint_end)
+                for _ in range(self.num_levels)
+            ]
+        )
+        self.mesh_up_embedders = nn.ModuleList(
+            [
+                utils.make_mlp([mesh_up_dim] + self.mlp_blueprint_end)
+                for _ in range(self.num_levels - 1)
+            ]
+        )
+        self.mesh_down_embedders = nn.ModuleList(
+            [
+                utils.make_mlp([mesh_down_dim] + self.mlp_blueprint_end)
+                for _ in range(self.num_levels - 1)
+            ]
+        )
+
+        # Instantiate GNNs
+        # Init GNNs
+        self.mesh_init_gnns = nn.ModuleList(
+            [
+                InteractionNet(
+                    edge_index,
+                    args.hidden_dim,
+                    hidden_layers=args.hidden_layers,
+                )
+                for edge_index in self.mesh_up_edge_index
+            ]
+        )
+
+        # Read out GNNs
+        self.mesh_read_gnns = nn.ModuleList(
+            [
+                InteractionNet(
+                    edge_index,
+                    args.hidden_dim,
+                    hidden_layers=args.hidden_layers,
+                    update_edges=False,
+                )
+                for edge_index in self.mesh_down_edge_index
+            ]
+        )
+
+    def get_num_mesh(self):
+        """
+        Compute number of mesh nodes from loaded features,
+        and number of mesh nodes that should be ignored in encoding/decoding
+        """
+        num_mesh_nodes = sum(
+            node_feat.shape[0] for node_feat in self.mesh_static_features
+        )
+        num_mesh_nodes_ignore = (
+            num_mesh_nodes - self.mesh_static_features[0].shape[0]
+        )
+        return num_mesh_nodes, num_mesh_nodes_ignore
+
+    def embedd_mesh_nodes(self):
+        """
+        Embed static mesh features
+        This embeds only bottom level, rest is done at beginning of
+        processing step
+        Returns tensor of shape (num_mesh_nodes[0], d_h)
+        """
+        return self.mesh_embedders[0](self.mesh_static_features[0])
+
+    def process_step(self, mesh_rep):
+        """
+        Process step of embedd-process-decode framework
+        Processes the representation on the mesh, possible in multiple steps
+
+        mesh_rep: has shape (B, num_mesh_nodes, d_h)
+        Returns mesh_rep: (B, num_mesh_nodes, d_h)
+        """
+        batch_size = mesh_rep.shape[0]
+
+        # EMBED REMAINING MESH NODES (levels >= 1) -
+        # Create list of mesh node representations for each level,
+        # each of size (B, num_mesh_nodes[l], d_h)
+        mesh_rep_levels = [mesh_rep] + [
+            self.expand_to_batch(emb(node_static_features), batch_size)
+            for emb, node_static_features in zip(
+                list(self.mesh_embedders)[1:],
+                list(self.mesh_static_features)[1:],
+            )
+        ]
+
+        # - EMBED EDGES -
+        # Embed edges, expand with batch dimension
+        mesh_same_rep = [
+            self.expand_to_batch(emb(edge_feat), batch_size)
+            for emb, edge_feat in zip(
+                self.mesh_same_embedders, self.m2m_features
+            )
+        ]
+        mesh_up_rep = [
+            self.expand_to_batch(emb(edge_feat), batch_size)
+            for emb, edge_feat in zip(
+                self.mesh_up_embedders, self.mesh_up_features
+            )
+        ]
+        mesh_down_rep = [
+            self.expand_to_batch(emb(edge_feat), batch_size)
+            for emb, edge_feat in zip(
+                self.mesh_down_embedders, self.mesh_down_features
+            )
+        ]
+
+        # - MESH INIT. -
+        # Let level_l go from 1 to L
+        for level_l, gnn in enumerate(self.mesh_init_gnns, start=1):
+            # Extract representations
+            send_node_rep = mesh_rep_levels[
+                level_l - 1
+            ]  # (B, num_mesh_nodes[l-1], d_h)
+            rec_node_rep = mesh_rep_levels[
+                level_l
+            ]  # (B, num_mesh_nodes[l], d_h)
+            edge_rep = mesh_up_rep[level_l - 1]
+
+            # Apply GNN
+            new_node_rep, new_edge_rep = gnn(
+                send_node_rep, rec_node_rep, edge_rep
+            )
+
+            # Update node and edge vectors in lists
+            mesh_rep_levels[level_l] = (
+                new_node_rep  # (B, num_mesh_nodes[l], d_h)
+            )
+            mesh_up_rep[level_l - 1] = new_edge_rep  # (B, M_up[l-1], d_h)
+
+        # - PROCESSOR -
+        mesh_rep_levels, _, _, mesh_down_rep = self.hi_processor_step(
+            mesh_rep_levels, mesh_same_rep, mesh_up_rep, mesh_down_rep
+        )
+
+        # - MESH READ OUT. -
+        # Let level_l go from L-1 to 0
+        for level_l, gnn in zip(
+            range(self.num_levels - 2, -1, -1), reversed(self.mesh_read_gnns)
+        ):
+            # Extract representations
+            send_node_rep = mesh_rep_levels[
+                level_l + 1
+            ]  # (B, num_mesh_nodes[l+1], d_h)
+            rec_node_rep = mesh_rep_levels[
+                level_l
+            ]  # (B, num_mesh_nodes[l], d_h)
+            edge_rep = mesh_down_rep[level_l]
+
+            # Apply GNN
+            new_node_rep = gnn(send_node_rep, rec_node_rep, edge_rep)
+
+            # Update node and edge vectors in lists
+            mesh_rep_levels[level_l] = (
+                new_node_rep  # (B, num_mesh_nodes[l], d_h)
+            )
+
+        # Return only bottom level representation
+        return mesh_rep_levels[0]  # (B, num_mesh_nodes[0], d_h)
+
+    def hi_processor_step(
+        self, mesh_rep_levels, mesh_same_rep, mesh_up_rep, mesh_down_rep
+    ):
+        """
+        Internal processor step of hierarchical graph models.
+        Between mesh init and read out.
+
+        Each input is list with representations, each with shape
+
+        mesh_rep_levels: (B, num_mesh_nodes[l], d_h)
+        mesh_same_rep: (B, M_same[l], d_h)
+        mesh_up_rep: (B, M_up[l -> l+1], d_h)
+        mesh_down_rep: (B, M_down[l <- l+1], d_h)
+
+        Returns same lists
+        """
+        raise NotImplementedError("hi_process_step not implemented")

--- a/neural_lam/models2/ensemble_forecaster_module.py
+++ b/neural_lam/models2/ensemble_forecaster_module.py
@@ -1,0 +1,135 @@
+# Third-party
+import torch
+
+# Local
+from ..metrics import crps_loss
+from .forecaster_module import ForecasterModule
+
+
+class EnsembleForecasterModule(ForecasterModule):
+    """
+    Probabilistic grading module using CRPS for ensemble forecasts.
+
+    Tensor shapes used by this module:
+    - `init_states`: (B, 2, N, F)
+    - `forcing_features`: (B, T, N, F_forcing)
+    - `target_states`: (B, T, N, F)
+    - `prediction`: (B, S, T, N, F)
+      where B=batch size, S=ensemble members, T=lead time, N=nodes,
+      F=state features.
+    """
+
+    def __init__(self, forecaster, args, config, datastore):
+        """
+        Initialize the ensemble forecasting module.
+
+        Parameters
+        ----------
+        forecaster : ARForecastSampler
+            Forecaster returning ensemble predictions with shape
+            (B, S, T, N, F).
+        args : Any
+            Runtime args namespace.
+        config : Any
+            Experiment/model config object.
+        datastore : BaseDatastore
+            Datastore used for metadata and plotting in parent module.
+        """
+        super().__init__(forecaster, args, config, datastore)
+        self.loss = crps_loss
+
+    @staticmethod
+    def _mask_node_dimension(tensor: torch.Tensor, interior_mask: torch.Tensor):
+        """
+        Apply interior-node mask to tensors with node dimension at index -2.
+
+        Supported shapes:
+        - (B, T, N, F)
+        - (B, S, T, N, F)
+        """
+        if interior_mask.dim() == 2:
+            mask_bool = interior_mask[:, 0].to(torch.bool)
+        else:
+            mask_bool = interior_mask.to(torch.bool)
+
+        if tensor.dim() == 4:
+            return tensor[:, :, mask_bool, :]
+        if tensor.dim() == 5:
+            return tensor[:, :, :, mask_bool, :]
+        raise ValueError("Expected tensor with dim 4 or 5 for masking")
+
+    def training_step(self, batch, batch_idx):
+        """
+        Train with CRPS over ensemble predictions.
+
+        Uses parent `common_step`:
+        - prediction: (B, S, T, N, F)
+        - target_states: (B, T, N, F)
+        """
+        _ = batch_idx
+        prediction, target_states, _, _ = self.common_step(batch)
+        interior_mask = self.forecaster.step_predictor.interior_mask
+
+        crps_entries = self.loss(
+            prediction,
+            target_states,
+            mask=interior_mask,
+            average_grid=False,
+            sum_vars=False,
+        )  # (B, T, N_int, F)
+        train_loss = torch.mean(crps_entries)
+
+        self.log(
+            "train_loss",
+            train_loss,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=batch[0].shape[0],
+        )
+        return train_loss
+
+    def validation_step(self, batch, batch_idx):
+        """
+        Validate with CRPS and spread-error diagnostics.
+
+        Logs:
+        - `val_crps`: mean CRPS over batch/time/node/feature.
+        - `val_spread`: mean ensemble variance.
+        - `val_error`: mean squared error of ensemble mean against truth.
+        """
+        _ = batch_idx
+        prediction, target_states, _, _ = self.common_step(batch)
+        interior_mask = self.forecaster.step_predictor.interior_mask
+
+        crps_entries = self.loss(
+            prediction,
+            target_states,
+            mask=interior_mask,
+            average_grid=False,
+            sum_vars=False,
+        )  # (B, T, N_int, F)
+        crps_per_timestep = torch.mean(crps_entries, dim=(0, 2, 3))  # (T,)
+        val_crps = torch.mean(crps_per_timestep)
+
+        ensemble_mean = torch.mean(prediction, dim=1)  # (B, T, N, F)
+        error_entries = (ensemble_mean - target_states) ** 2
+        spread_entries = torch.var(prediction, dim=1, unbiased=False)
+
+        error_entries = self._mask_node_dimension(error_entries, interior_mask)
+        spread_entries = self._mask_node_dimension(spread_entries, interior_mask)
+        val_error = torch.mean(error_entries)
+        val_spread = torch.mean(spread_entries)
+
+        self.log_dict(
+            {
+                "val_crps": val_crps,
+                "val_spread": val_spread,
+                "val_error": val_error,
+            },
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=batch[0].shape[0],
+        )

--- a/neural_lam/models2/forecaster.py
+++ b/neural_lam/models2/forecaster.py
@@ -1,0 +1,21 @@
+# Third-party
+from torch import nn
+
+
+class Forecaster(nn.Module):
+    """
+    Base class for full-horizon forecasting modules.
+    """
+
+    def forward(
+        self,
+        init_states,
+        forcing_features,
+        true_states=None,
+        pred_steps=None,
+        ensemble_size=1,
+    ):
+        """
+        Build a full forecast horizon.
+        """
+        raise NotImplementedError("Subclasses must implement forward")

--- a/neural_lam/models2/forecaster_module.py
+++ b/neural_lam/models2/forecaster_module.py
@@ -1,0 +1,584 @@
+# Standard library
+import os
+import warnings
+from typing import Any, Dict, List
+
+# Third-party
+import matplotlib.pyplot as plt
+import numpy as np
+import pytorch_lightning as pl
+import torch
+import xarray as xr
+
+# First-party
+from neural_lam.utils import get_integer_time
+
+# Local
+from .. import metrics, vis
+from ..datastore import BaseDatastore
+from ..weather_dataset import WeatherDataset
+from .forecaster import Forecaster
+
+
+class ForecasterModule(pl.LightningModule):
+    """
+    Lightning wrapper that handles training/evaluation around a Forecaster.
+    """
+
+    # pylint: disable=arguments-differ
+    def __init__(
+        self,
+        forecaster: Forecaster,
+        args,
+        config=None,
+        datastore: BaseDatastore = None,
+    ):
+        super().__init__()
+
+        # Backward compatibility for old positional order:
+        # ForecasterModule(args, forecaster, datastore)
+        if not hasattr(forecaster, "step_predictor") and hasattr(
+            args, "step_predictor"
+        ):
+            old_args = forecaster
+            old_forecaster = args
+            old_datastore = config
+            forecaster = old_forecaster
+            args = old_args
+            config = None
+            datastore = old_datastore
+
+        self.save_hyperparameters(ignore=["datastore", "forecaster", "config"])
+
+        self.args = args
+        self.forecaster = forecaster
+        self.config = config
+        self._datastore = datastore
+        if self._datastore is None:
+            raise ValueError("datastore must be provided to ForecasterModule")
+
+        if not hasattr(self.forecaster, "step_predictor"):
+            raise ValueError(
+                "ForecasterModule currently expects forecaster.step_predictor"
+            )
+
+        # Instantiate loss function
+        self.loss = metrics.get_metric(args.loss)
+
+        self.val_metrics: Dict[str, List] = {
+            "mse": [],
+        }
+        self.test_metrics: Dict[str, List] = {
+            "mse": [],
+            "mae": [],
+        }
+        if self.output_std:
+            self.test_metrics["output_std"] = []  # Treat as metric
+
+        # For making restoring of optimizer state optional
+        self.restore_opt = args.restore_opt
+
+        # For example plotting
+        self.n_example_pred = args.n_example_pred
+        self.plotted_examples = 0
+
+        # For storing spatial loss maps during evaluation
+        self.spatial_loss_maps: List[Any] = []
+
+        self.time_step_int, self.time_step_unit = get_integer_time(
+            self._datastore.step_length
+        )
+
+    @property
+    def step_predictor(self):
+        """
+        Expose underlying one-step predictor.
+        """
+        return self.forecaster.step_predictor
+
+    @property
+    def output_std(self) -> bool:
+        """
+        Whether the step predictor returns predictive std.
+        """
+        return bool(self.step_predictor.output_std)
+
+    @property
+    def state_mean(self):
+        """
+        Shortcut to state mean buffer.
+        """
+        return self.step_predictor.state_mean
+
+    @property
+    def state_std(self):
+        """
+        Shortcut to state std buffer.
+        """
+        return self.step_predictor.state_std
+
+    @property
+    def interior_mask_bool(self):
+        """
+        Get the interior mask as a boolean (N,) mask.
+        """
+        return self.step_predictor.interior_mask[:, 0].to(torch.bool)
+
+    def _create_dataarray_from_tensor(
+        self,
+        tensor: torch.Tensor,
+        time: torch.Tensor,
+        split: str,
+        category: str,
+    ) -> xr.DataArray:
+        """
+        Create an xr.DataArray matching the datastore coordinates.
+        """
+        # TODO: creating an instance of WeatherDataset here on every call is
+        # not how this should be done but whether WeatherDataset should be
+        # provided to ForecasterModule or where to put plotting still needs
+        # discussion.
+        weather_dataset = WeatherDataset(datastore=self._datastore, split=split)
+        time = np.array(time.cpu(), dtype="datetime64[ns]")
+        da = weather_dataset.create_dataarray_from_tensor(
+            tensor=tensor, time=time, category=category
+        )
+        return da
+
+    def configure_optimizers(self):
+        """
+        Configure optimizer.
+        """
+        opt = torch.optim.AdamW(
+            self.parameters(), lr=self.args.lr, betas=(0.9, 0.95)
+        )
+        return opt
+
+    def common_step(self, batch):
+        """
+        Predict on a single batch.
+
+        batch consists of:
+        init_states: (B, 2, num_grid_nodes, d_features)
+        target_states: (B, pred_steps, num_grid_nodes, d_features)
+        forcing_features: (B, pred_steps, num_grid_nodes, d_forcing)
+        """
+        (init_states, target_states, forcing_features, batch_times) = batch
+
+        prediction, pred_std = self.forecaster(
+            init_states=init_states,
+            forcing_features=forcing_features,
+            true_states=target_states,
+            ensemble_size=getattr(self.args, "ensemble_size", 1),
+        )  # (B, pred_steps, num_grid_nodes, d_f)
+
+        if pred_std is None and not self.output_std:
+            pred_std = self.step_predictor.per_var_std  # (d_f,)
+
+        return prediction, target_states, pred_std, batch_times
+
+    def training_step(self, batch):
+        """
+        Train on single batch.
+        """
+        prediction, target, pred_std, _ = self.common_step(batch)
+
+        # Compute loss
+        batch_loss = torch.mean(
+            self.loss(
+                prediction, target, pred_std, mask=self.interior_mask_bool
+            )
+        )  # mean over unrolled times and batch
+
+        log_dict = {"train_loss": batch_loss}
+        self.log_dict(
+            log_dict,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=batch[0].shape[0],
+        )
+        return batch_loss
+
+    def all_gather_cat(self, tensor_to_gather):
+        """
+        Gather tensors across all ranks and concatenate dim 0.
+        """
+        gathered = self.all_gather(tensor_to_gather)
+        # all_gather adds a leading dim (K,) only on multi-device runs;
+        # on single-device it returns the tensor unchanged.
+        if gathered.dim() > tensor_to_gather.dim():
+            return gathered.flatten(0, 1)
+        return gathered
+
+    # newer lightning versions requires batch_idx argument, even if unused
+    # pylint: disable-next=unused-argument
+    def validation_step(self, batch, batch_idx):
+        """
+        Run validation on single batch.
+        """
+        prediction, target, pred_std, _ = self.common_step(batch)
+
+        time_step_loss = torch.mean(
+            self.loss(
+                prediction, target, pred_std, mask=self.interior_mask_bool
+            ),
+            dim=0,
+        )  # (time_steps-1,)
+        mean_loss = torch.mean(time_step_loss)
+
+        # Log loss per time step forward and mean
+        val_log_dict = {
+            f"val_loss_unroll{step}": time_step_loss[step - 1]
+            for step in self.args.val_steps_to_log
+            if step <= len(time_step_loss)
+        }
+        val_log_dict["val_mean_loss"] = mean_loss
+        self.log_dict(
+            val_log_dict,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=batch[0].shape[0],
+        )
+
+        # Store MSEs
+        entry_mses = metrics.mse(
+            prediction,
+            target,
+            pred_std,
+            mask=self.interior_mask_bool,
+            sum_vars=False,
+        )  # (B, pred_steps, d_f)
+        self.val_metrics["mse"].append(entry_mses)
+
+    def on_validation_epoch_end(self):
+        """
+        Compute val metrics at the end of val epoch.
+        """
+        self.aggregate_and_plot_metrics(self.val_metrics, prefix="val")
+        for metric_list in self.val_metrics.values():
+            metric_list.clear()
+
+    # pylint: disable-next=unused-argument
+    def test_step(self, batch, batch_idx):
+        """
+        Run test on single batch.
+        """
+        prediction, target, pred_std, batch_times = self.common_step(batch)
+        _ = batch_times
+
+        time_step_loss = torch.mean(
+            self.loss(
+                prediction, target, pred_std, mask=self.interior_mask_bool
+            ),
+            dim=0,
+        )  # (time_steps-1,)
+        mean_loss = torch.mean(time_step_loss)
+
+        # Log loss per time step forward and mean
+        test_log_dict = {
+            f"test_loss_unroll{step}": time_step_loss[step - 1]
+            for step in self.args.val_steps_to_log
+            if step <= len(time_step_loss)
+        }
+        test_log_dict["test_mean_loss"] = mean_loss
+
+        self.log_dict(
+            test_log_dict,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=batch[0].shape[0],
+        )
+
+        # Compute all evaluation metrics for error maps.
+        for metric_name in ("mse", "mae"):
+            metric_func = metrics.get_metric(metric_name)
+            batch_metric_vals = metric_func(
+                prediction,
+                target,
+                pred_std,
+                mask=self.interior_mask_bool,
+                sum_vars=False,
+            )  # (B, pred_steps, d_f)
+            self.test_metrics[metric_name].append(batch_metric_vals)
+
+        if self.output_std:
+            # Store output std. per variable, spatially averaged
+            mean_pred_std = torch.mean(
+                pred_std[..., self.interior_mask_bool, :], dim=-2
+            )  # (B, pred_steps, d_f)
+            self.test_metrics["output_std"].append(mean_pred_std)
+
+        # Save per-sample spatial loss for specific times
+        spatial_loss = self.loss(
+            prediction, target, pred_std, average_grid=False
+        )  # (B, pred_steps, num_grid_nodes)
+        log_spatial_losses = spatial_loss[
+            :, [step - 1 for step in self.args.val_steps_to_log]
+        ]
+        self.spatial_loss_maps.append(log_spatial_losses)
+        # (B, N_log, num_grid_nodes)
+
+        # Plot example predictions (on rank 0 only)
+        if (
+            self.trainer.is_global_zero
+            and self.plotted_examples < self.n_example_pred
+        ):
+            n_additional_examples = min(
+                prediction.shape[0],
+                self.n_example_pred - self.plotted_examples,
+            )
+            self.plot_examples(
+                batch,
+                n_additional_examples,
+                prediction=prediction,
+                split="test",
+            )
+
+    def plot_examples(self, batch, n_examples, split, prediction=None):
+        """
+        Plot first n_examples forecasts from a batch.
+        """
+        if prediction is None:
+            prediction, target, _, _ = self.common_step(batch)
+            _ = target
+
+        target = batch[1]
+        time = batch[3]
+
+        # Rescale to original data scale
+        prediction_rescaled = prediction * self.state_std + self.state_mean
+        target_rescaled = target * self.state_std + self.state_mean
+
+        # Iterate over the examples
+        for pred_slice, target_slice, time_slice in zip(
+            prediction_rescaled[:n_examples],
+            target_rescaled[:n_examples],
+            time[:n_examples],
+        ):
+            self.plotted_examples += 1
+
+            da_prediction = self._create_dataarray_from_tensor(
+                tensor=pred_slice,
+                time=time_slice,
+                split=split,
+                category="state",
+            ).unstack("grid_index")
+            da_target = self._create_dataarray_from_tensor(
+                tensor=target_slice,
+                time=time_slice,
+                split=split,
+                category="state",
+            ).unstack("grid_index")
+
+            var_vmin = (
+                torch.minimum(
+                    pred_slice.flatten(0, 1).min(dim=0)[0],
+                    target_slice.flatten(0, 1).min(dim=0)[0],
+                )
+                .cpu()
+                .numpy()
+            )
+            var_vmax = (
+                torch.maximum(
+                    pred_slice.flatten(0, 1).max(dim=0)[0],
+                    target_slice.flatten(0, 1).max(dim=0)[0],
+                )
+                .cpu()
+                .numpy()
+            )
+            var_vranges = list(zip(var_vmin, var_vmax))
+
+            # Iterate over prediction horizon time steps
+            for t_i, _ in enumerate(zip(pred_slice, target_slice), start=1):
+                var_figs = [
+                    vis.plot_prediction(
+                        datastore=self._datastore,
+                        title=f"{var_name}, t={t_i}"
+                        f" ({self.time_step_int * t_i}"
+                        f"{self.time_step_unit})",
+                        colorbar_label=var_unit,
+                        vrange=var_vrange,
+                        da_prediction=da_prediction.isel(
+                            state_feature=var_i, time=t_i - 1
+                        ).squeeze(),
+                        da_target=da_target.isel(
+                            state_feature=var_i, time=t_i - 1
+                        ).squeeze(),
+                    )
+                    for var_i, (var_name, var_unit, var_vrange) in enumerate(
+                        zip(
+                            self._datastore.get_vars_names("state"),
+                            self._datastore.get_vars_units("state"),
+                            var_vranges,
+                        )
+                    )
+                ]
+
+                example_i = self.plotted_examples
+
+                for var_name, fig in zip(
+                    self._datastore.get_vars_names("state"), var_figs
+                ):
+                    # Logger behavior differs between wandb and others.
+                    if isinstance(self.logger, pl.loggers.WandbLogger):
+                        key = f"{var_name}_example_{example_i}"
+                    else:
+                        key = f"{var_name}_example"
+
+                    if hasattr(self.logger, "log_image"):
+                        self.logger.log_image(key=key, images=[fig], step=t_i)
+                    else:
+                        warnings.warn(
+                            f"{self.logger} does not support image logging."
+                        )
+
+                plt.close("all")
+
+            # Save pred and target as .pt files
+            torch.save(
+                pred_slice.cpu(),
+                os.path.join(
+                    self.logger.save_dir,
+                    f"example_pred_{self.plotted_examples}.pt",
+                ),
+            )
+            torch.save(
+                target_slice.cpu(),
+                os.path.join(
+                    self.logger.save_dir,
+                    f"example_target_{self.plotted_examples}.pt",
+                ),
+            )
+
+    def create_metric_log_dict(self, metric_tensor, prefix, metric_name):
+        """
+        Build metric figure dict for logger.
+        """
+        log_dict = {}
+        metric_fig = vis.plot_error_map(
+            errors=metric_tensor,
+            datastore=self._datastore,
+        )
+        full_log_name = f"{prefix}_{metric_name}"
+        log_dict[full_log_name] = metric_fig
+
+        if prefix == "test":
+            metric_fig.savefig(
+                os.path.join(self.logger.save_dir, f"{full_log_name}.pdf")
+            )
+            np.savetxt(
+                os.path.join(self.logger.save_dir, f"{full_log_name}.csv"),
+                metric_tensor.cpu().numpy(),
+                delimiter=",",
+            )
+
+        var_names = self._datastore.get_vars_names(category="state")
+        if full_log_name in self.args.metrics_watch:
+            for var_i, timesteps in self.args.var_leads_metrics_watch.items():
+                var_name = var_names[var_i]
+                for step in timesteps:
+                    key = f"{full_log_name}_{var_name}_step_{step}"
+                    log_dict[key] = metric_tensor[step - 1, var_i]
+
+        return log_dict
+
+    def aggregate_and_plot_metrics(self, metrics_dict, prefix):
+        """
+        Aggregate and create error map plots for all metrics in metrics_dict.
+        """
+        log_dict = {}
+        for metric_name, metric_val_list in metrics_dict.items():
+            metric_tensor = self.all_gather_cat(
+                torch.cat(metric_val_list, dim=0)
+            )  # (N_eval, pred_steps, d_f)
+
+            if self.trainer.is_global_zero:
+                metric_tensor_averaged = torch.mean(metric_tensor, dim=0)
+                # Take square root after all averaging to change MSE to RMSE
+                if "mse" in metric_name:
+                    metric_tensor_averaged = torch.sqrt(metric_tensor_averaged)
+                    metric_name = metric_name.replace("mse", "rmse")
+
+                metric_rescaled = metric_tensor_averaged * self.state_std
+                log_dict.update(
+                    self.create_metric_log_dict(
+                        metric_rescaled, prefix, metric_name
+                    )
+                )
+
+        assert all(
+            isinstance(key, str) and isinstance(value, plt.Figure)
+            for key, value in log_dict.items()
+        )
+
+        if self.trainer.is_global_zero and not self.trainer.sanity_checking:
+            current_epoch = self.trainer.current_epoch
+            for key, figure in log_dict.items():
+                if not isinstance(self.logger, pl.loggers.WandbLogger):
+                    key = f"{key}-{current_epoch}"
+                if hasattr(self.logger, "log_image"):
+                    self.logger.log_image(key=key, images=[figure])
+
+            plt.close("all")
+
+    def on_test_epoch_end(self):
+        """
+        Compute test metrics and make plots at end of test epoch.
+        """
+        self.aggregate_and_plot_metrics(self.test_metrics, prefix="test")
+
+        spatial_loss_tensor = self.all_gather_cat(
+            torch.cat(self.spatial_loss_maps, dim=0)
+        )  # (N_test, N_log, num_grid_nodes)
+        if self.trainer.is_global_zero:
+            mean_spatial_loss = torch.mean(spatial_loss_tensor, dim=0)
+
+            loss_map_figs = [
+                vis.plot_spatial_error(
+                    error=loss_map,
+                    datastore=self._datastore,
+                    title=f"Test loss, t={t_i} "
+                    f"({(self.time_step_int * t_i)} {self.time_step_unit})",
+                )
+                for t_i, loss_map in zip(
+                    self.args.val_steps_to_log, mean_spatial_loss
+                )
+            ]
+
+            for i, fig in enumerate(loss_map_figs):
+                key = "test_loss"
+                if not isinstance(self.logger, pl.loggers.WandbLogger):
+                    key = f"{key}_{i}"
+                if hasattr(self.logger, "log_image"):
+                    self.logger.log_image(key=key, images=[fig])
+
+            pdf_loss_map_figs = [
+                vis.plot_spatial_error(
+                    error=loss_map, datastore=self._datastore
+                )
+                for loss_map in mean_spatial_loss
+            ]
+            pdf_loss_maps_dir = os.path.join(
+                self.logger.save_dir, "spatial_loss_maps"
+            )
+            os.makedirs(pdf_loss_maps_dir, exist_ok=True)
+            for t_i, fig in zip(self.args.val_steps_to_log, pdf_loss_map_figs):
+                fig.savefig(os.path.join(pdf_loss_maps_dir, f"loss_t{t_i}.pdf"))
+            torch.save(
+                mean_spatial_loss.cpu(),
+                os.path.join(self.logger.save_dir, "mean_spatial_loss.pt"),
+            )
+
+        self.spatial_loss_maps.clear()
+
+    def on_load_checkpoint(self, checkpoint):
+        """
+        Perform any changes to state dict before loading checkpoint.
+        """
+        if not self.restore_opt:
+            opt = self.configure_optimizers()
+            checkpoint["optimizer_states"] = [opt.state_dict()]

--- a/neural_lam/models2/graph_lam.py
+++ b/neural_lam/models2/graph_lam.py
@@ -1,0 +1,91 @@
+# Third-party
+import torch_geometric as pyg
+
+# Local
+from .. import utils
+from ..config import NeuralLAMConfig
+from ..datastore import BaseDatastore
+from ..interaction_net import InteractionNet
+from .base_graph_model import BaseGraphModel
+
+
+class GraphLAM(BaseGraphModel):
+    """
+    Full graph-based LAM model that can be used with different
+    (non-hierarchical )graphs. Mainly based on GraphCast, but the model from
+    Keisler (2022) is almost identical. Used for GC-LAM and L1-LAM in
+    Oskarsson et al. (2023).
+    """
+
+    def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
+        super().__init__(args, config=config, datastore=datastore)
+
+        assert (
+            not self.hierarchical
+        ), "GraphLAM does not use a hierarchical mesh graph"
+
+        # grid_dim from data + static + batch_static
+        mesh_dim = self.mesh_static_features.shape[1]
+        m2m_edges, m2m_dim = self.m2m_features.shape
+        utils.log_on_rank_zero(
+            f"Edges in subgraphs: m2m={m2m_edges}, g2m={self.g2m_edges}, "
+            f"m2g={self.m2g_edges}"
+        )
+
+        # Define sub-models
+        # Feature embedders for mesh
+        self.mesh_embedder = utils.make_mlp([mesh_dim] + self.mlp_blueprint_end)
+        self.m2m_embedder = utils.make_mlp([m2m_dim] + self.mlp_blueprint_end)
+
+        # GNNs
+        # processor
+        processor_nets = [
+            InteractionNet(
+                self.m2m_edge_index,
+                args.hidden_dim,
+                hidden_layers=args.hidden_layers,
+                aggr=args.mesh_aggr,
+            )
+            for _ in range(args.processor_layers)
+        ]
+        self.processor = pyg.nn.Sequential(
+            "mesh_rep, edge_rep",
+            [
+                (net, "mesh_rep, mesh_rep, edge_rep -> mesh_rep, edge_rep")
+                for net in processor_nets
+            ],
+        )
+
+    def get_num_mesh(self):
+        """
+        Compute number of mesh nodes from loaded features,
+        and number of mesh nodes that should be ignored in encoding/decoding
+        """
+        return self.mesh_static_features.shape[0], 0
+
+    def embedd_mesh_nodes(self):
+        """
+        Embed static mesh features
+        Returns tensor of shape (N_mesh, d_h)
+        """
+        return self.mesh_embedder(self.mesh_static_features)  # (N_mesh, d_h)
+
+    def process_step(self, mesh_rep):
+        """
+        Process step of embedd-process-decode framework
+        Processes the representation on the mesh, possible in multiple steps
+
+        mesh_rep: has shape (B, N_mesh, d_h)
+        Returns mesh_rep: (B, N_mesh, d_h)
+        """
+        # Embed m2m here first
+        batch_size = mesh_rep.shape[0]
+        m2m_emb = self.m2m_embedder(self.m2m_features)  # (M_mesh, d_h)
+        m2m_emb_expanded = self.expand_to_batch(
+            m2m_emb, batch_size
+        )  # (B, M_mesh, d_h)
+
+        mesh_rep, _ = self.processor(
+            mesh_rep, m2m_emb_expanded
+        )  # (B, N_mesh, d_h)
+        return mesh_rep

--- a/neural_lam/models2/hi_lam.py
+++ b/neural_lam/models2/hi_lam.py
@@ -1,0 +1,207 @@
+# Third-party
+from torch import nn
+
+# Local
+from ..config import NeuralLAMConfig
+from ..datastore import BaseDatastore
+from ..interaction_net import InteractionNet
+from .base_hi_graph_model import BaseHiGraphModel
+
+
+class HiLAM(BaseHiGraphModel):
+    """
+    Hierarchical graph model with message passing that goes sequentially down
+    and up the hierarchy during processing.
+    The Hi-LAM model from Oskarsson et al. (2023)
+    """
+
+    def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
+        super().__init__(args, config=config, datastore=datastore)
+
+        # Make down GNNs, both for down edges and same level
+        self.mesh_down_gnns = nn.ModuleList(
+            [self.make_down_gnns(args) for _ in range(args.processor_layers)]
+        )  # Nested lists (proc_steps, num_levels-1)
+        self.mesh_down_same_gnns = nn.ModuleList(
+            [self.make_same_gnns(args) for _ in range(args.processor_layers)]
+        )  # Nested lists (proc_steps, num_levels)
+
+        # Make up GNNs, both for up edges and same level
+        self.mesh_up_gnns = nn.ModuleList(
+            [self.make_up_gnns(args) for _ in range(args.processor_layers)]
+        )  # Nested lists (proc_steps, num_levels-1)
+        self.mesh_up_same_gnns = nn.ModuleList(
+            [self.make_same_gnns(args) for _ in range(args.processor_layers)]
+        )  # Nested lists (proc_steps, num_levels)
+
+    def make_same_gnns(self, args):
+        """
+        Make intra-level GNNs.
+        """
+        return nn.ModuleList(
+            [
+                InteractionNet(
+                    edge_index,
+                    args.hidden_dim,
+                    hidden_layers=args.hidden_layers,
+                )
+                for edge_index in self.m2m_edge_index
+            ]
+        )
+
+    def make_up_gnns(self, args):
+        """
+        Make GNNs for processing steps up through the hierarchy.
+        """
+        return nn.ModuleList(
+            [
+                InteractionNet(
+                    edge_index,
+                    args.hidden_dim,
+                    hidden_layers=args.hidden_layers,
+                )
+                for edge_index in self.mesh_up_edge_index
+            ]
+        )
+
+    def make_down_gnns(self, args):
+        """
+        Make GNNs for processing steps down through the hierarchy.
+        """
+        return nn.ModuleList(
+            [
+                InteractionNet(
+                    edge_index,
+                    args.hidden_dim,
+                    hidden_layers=args.hidden_layers,
+                )
+                for edge_index in self.mesh_down_edge_index
+            ]
+        )
+
+    def mesh_down_step(
+        self,
+        mesh_rep_levels,
+        mesh_same_rep,
+        mesh_down_rep,
+        down_gnns,
+        same_gnns,
+    ):
+        """
+        Run down-part of vertical processing, sequentially alternating between
+        processing using down edges and same-level edges.
+        """
+        # Run same level processing on level L
+        mesh_rep_levels[-1], mesh_same_rep[-1] = same_gnns[-1](
+            mesh_rep_levels[-1], mesh_rep_levels[-1], mesh_same_rep[-1]
+        )
+
+        # Let level_l go from L-1 to 0
+        for level_l, down_gnn, same_gnn in zip(
+            range(self.num_levels - 2, -1, -1),
+            reversed(down_gnns),
+            reversed(same_gnns[:-1]),
+        ):
+            # Extract representations
+            send_node_rep = mesh_rep_levels[
+                level_l + 1
+            ]  # (B, N_mesh[l+1], d_h)
+            rec_node_rep = mesh_rep_levels[level_l]  # (B, N_mesh[l], d_h)
+            down_edge_rep = mesh_down_rep[level_l]
+            same_edge_rep = mesh_same_rep[level_l]
+
+            # Apply down GNN
+            new_node_rep, mesh_down_rep[level_l] = down_gnn(
+                send_node_rep, rec_node_rep, down_edge_rep
+            )
+
+            # Run same level processing on level l
+            mesh_rep_levels[level_l], mesh_same_rep[level_l] = same_gnn(
+                new_node_rep, new_node_rep, same_edge_rep
+            )
+            # (B, N_mesh[l], d_h) and (B, M_same[l], d_h)
+
+        return mesh_rep_levels, mesh_same_rep, mesh_down_rep
+
+    def mesh_up_step(
+        self, mesh_rep_levels, mesh_same_rep, mesh_up_rep, up_gnns, same_gnns
+    ):
+        """
+        Run up-part of vertical processing, sequentially alternating between
+        processing using up edges and same-level edges.
+        """
+
+        # Run same level processing on level 0
+        mesh_rep_levels[0], mesh_same_rep[0] = same_gnns[0](
+            mesh_rep_levels[0], mesh_rep_levels[0], mesh_same_rep[0]
+        )
+
+        # Let level_l go from 1 to L
+        for level_l, (up_gnn, same_gnn) in enumerate(
+            zip(up_gnns, same_gnns[1:]), start=1
+        ):
+            # Extract representations
+            send_node_rep = mesh_rep_levels[
+                level_l - 1
+            ]  # (B, N_mesh[l-1], d_h)
+            rec_node_rep = mesh_rep_levels[level_l]  # (B, N_mesh[l], d_h)
+            up_edge_rep = mesh_up_rep[level_l - 1]
+            same_edge_rep = mesh_same_rep[level_l]
+
+            # Apply up GNN
+            new_node_rep, mesh_up_rep[level_l - 1] = up_gnn(
+                send_node_rep, rec_node_rep, up_edge_rep
+            )
+            # (B, N_mesh[l], d_h) and (B, M_up[l-1], d_h)
+
+            # Run same level processing on level l
+            mesh_rep_levels[level_l], mesh_same_rep[level_l] = same_gnn(
+                new_node_rep, new_node_rep, same_edge_rep
+            )
+            # (B, N_mesh[l], d_h) and (B, M_same[l], d_h)
+
+        return mesh_rep_levels, mesh_same_rep, mesh_up_rep
+
+    def hi_processor_step(
+        self, mesh_rep_levels, mesh_same_rep, mesh_up_rep, mesh_down_rep
+    ):
+        """
+        Internal processor step of hierarchical graph models.
+        Between mesh init and read out.
+
+        Each input is list with representations, each with shape
+
+        mesh_rep_levels: (B, N_mesh[l], d_h)
+        mesh_same_rep: (B, M_same[l], d_h)
+        mesh_up_rep: (B, M_up[l -> l+1], d_h)
+        mesh_down_rep: (B, M_down[l <- l+1], d_h)
+
+        Returns same lists
+        """
+        for down_gnns, down_same_gnns, up_gnns, up_same_gnns in zip(
+            self.mesh_down_gnns,
+            self.mesh_down_same_gnns,
+            self.mesh_up_gnns,
+            self.mesh_up_same_gnns,
+        ):
+            # Down
+            mesh_rep_levels, mesh_same_rep, mesh_down_rep = self.mesh_down_step(
+                mesh_rep_levels,
+                mesh_same_rep,
+                mesh_down_rep,
+                down_gnns,
+                down_same_gnns,
+            )
+
+            # Up
+            mesh_rep_levels, mesh_same_rep, mesh_up_rep = self.mesh_up_step(
+                mesh_rep_levels,
+                mesh_same_rep,
+                mesh_up_rep,
+                up_gnns,
+                up_same_gnns,
+            )
+
+        # NOTE: We return all, even though only down edges really are used
+        # later
+        return mesh_rep_levels, mesh_same_rep, mesh_up_rep, mesh_down_rep

--- a/neural_lam/models2/hi_lam_parallel.py
+++ b/neural_lam/models2/hi_lam_parallel.py
@@ -1,0 +1,99 @@
+# Third-party
+import torch
+import torch_geometric as pyg
+
+# Local
+from ..config import NeuralLAMConfig
+from ..datastore import BaseDatastore
+from ..interaction_net import InteractionNet
+from .base_hi_graph_model import BaseHiGraphModel
+
+
+class HiLAMParallel(BaseHiGraphModel):
+    """
+    Version of HiLAM where all message passing in the hierarchical mesh (up,
+    down, inter-level) is ran in parallel.
+
+    This is a somewhat simpler alternative to the sequential message passing
+    of Hi-LAM.
+    """
+
+    def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
+        super().__init__(args, config=config, datastore=datastore)
+
+        # Processor GNNs
+        # Create the complete edge_index combining all edges for processing
+        total_edge_index_list = (
+            list(self.m2m_edge_index)
+            + list(self.mesh_up_edge_index)
+            + list(self.mesh_down_edge_index)
+        )
+        total_edge_index = torch.cat(total_edge_index_list, dim=1)
+        self.edge_split_sections = [ei.shape[1] for ei in total_edge_index_list]
+
+        if args.processor_layers == 0:
+            self.processor = lambda x, edge_attr: (x, edge_attr)
+        else:
+            processor_nets = [
+                InteractionNet(
+                    total_edge_index,
+                    args.hidden_dim,
+                    hidden_layers=args.hidden_layers,
+                    edge_chunk_sizes=self.edge_split_sections,
+                    aggr_chunk_sizes=self.level_mesh_sizes,
+                )
+                for _ in range(args.processor_layers)
+            ]
+            self.processor = pyg.nn.Sequential(
+                "mesh_rep, edge_rep",
+                [
+                    (net, "mesh_rep, mesh_rep, edge_rep -> mesh_rep, edge_rep")
+                    for net in processor_nets
+                ],
+            )
+
+    def hi_processor_step(
+        self, mesh_rep_levels, mesh_same_rep, mesh_up_rep, mesh_down_rep
+    ):
+        """
+        Internal processor step of hierarchical graph models.
+        Between mesh init and read out.
+
+        Each input is list with representations, each with shape
+
+        mesh_rep_levels: (B, N_mesh[l], d_h)
+        mesh_same_rep: (B, M_same[l], d_h)
+        mesh_up_rep: (B, M_up[l -> l+1], d_h)
+        mesh_down_rep: (B, M_down[l <- l+1], d_h)
+
+        Returns same lists
+        """
+
+        # First join all node and edge representations to single tensors
+        mesh_rep = torch.cat(mesh_rep_levels, dim=1)  # (B, N_mesh, d_h)
+        mesh_edge_rep = torch.cat(
+            mesh_same_rep + mesh_up_rep + mesh_down_rep, axis=1
+        )  # (B, M_mesh, d_h)
+
+        # Here, update mesh_*_rep and mesh_rep
+        mesh_rep, mesh_edge_rep = self.processor(mesh_rep, mesh_edge_rep)
+
+        # Split up again for read-out step
+        mesh_rep_levels = list(
+            torch.split(mesh_rep, self.level_mesh_sizes, dim=1)
+        )
+        mesh_edge_rep_sections = torch.split(
+            mesh_edge_rep, self.edge_split_sections, dim=1
+        )
+
+        mesh_same_rep = mesh_edge_rep_sections[: self.num_levels]
+        mesh_up_rep = mesh_edge_rep_sections[
+            self.num_levels : self.num_levels + (self.num_levels - 1)
+        ]
+        mesh_down_rep = mesh_edge_rep_sections[
+            self.num_levels + (self.num_levels - 1) :
+        ]  # Last are down edges
+
+        # TODO: We return all, even though only down edges really are used
+        # later
+        return mesh_rep_levels, mesh_same_rep, mesh_up_rep, mesh_down_rep

--- a/neural_lam/models2/step_predictor.py
+++ b/neural_lam/models2/step_predictor.py
@@ -1,0 +1,126 @@
+# Third-party
+import torch
+from torch import nn
+
+# Local
+from ..config import NeuralLAMConfig
+from ..datastore import BaseDatastore
+from ..loss_weighting import get_state_feature_weighting
+
+
+class StepPredictor(nn.Module):
+    """
+    Base class for one-step predictors mapping
+    (X_{t-1}, X_t, forcing_t) -> X_{t+1}.
+    """
+
+    def __init__(
+        self,
+        args,
+        config: NeuralLAMConfig,
+        datastore: BaseDatastore,
+    ):
+        super().__init__()
+        self.args = args
+        self._datastore = datastore
+
+        # Data dimensions
+        num_state_vars = datastore.get_num_data_vars(category="state")
+        num_forcing_vars = datastore.get_num_data_vars(category="forcing")
+        num_past_forcing_steps = args.num_past_forcing_steps
+        num_future_forcing_steps = args.num_future_forcing_steps
+
+        # Static grid features are required by existing graph predictors
+        da_static_features = datastore.get_dataarray(
+            category="static", split=None, standardize=True
+        )
+        if da_static_features is None:
+            raise ValueError("Static features are required for StepPredictor")
+
+        # Register static features
+        self.register_buffer(
+            "grid_static_features",
+            torch.tensor(da_static_features.values, dtype=torch.float32),
+            persistent=False,
+        )
+
+        # Output dimensions
+        self.output_std = bool(args.output_std)
+        if self.output_std:
+            self.grid_output_dim = 2 * num_state_vars
+        else:
+            self.grid_output_dim = num_state_vars
+
+        # Grid dimensions from input state + static + forcing window
+        (
+            self.num_grid_nodes,
+            grid_static_dim,
+        ) = self.grid_static_features.shape
+
+        self.grid_dim = (
+            2 * num_state_vars
+            + grid_static_dim
+            + num_forcing_vars
+            * (num_past_forcing_steps + num_future_forcing_steps + 1)
+        )
+
+        # Standardization statistics
+        da_state_stats = datastore.get_standardization_dataarray(category="state")
+        state_stats = {
+            "state_mean": torch.tensor(
+                da_state_stats.state_mean.values, dtype=torch.float32
+            ),
+            "state_std": torch.tensor(
+                da_state_stats.state_std.values, dtype=torch.float32
+            ),
+            "diff_mean": torch.tensor(
+                da_state_stats.state_diff_mean_standardized.values,
+                dtype=torch.float32,
+            ),
+            "diff_std": torch.tensor(
+                da_state_stats.state_diff_std_standardized.values,
+                dtype=torch.float32,
+            ),
+        }
+        for key, val in state_stats.items():
+            self.register_buffer(key, val, persistent=False)
+
+        # Feature weighting is currently still used for constant output std
+        state_feature_weights = get_state_feature_weighting(
+            config=config, datastore=datastore
+        )
+        self.register_buffer(
+            "feature_weights",
+            torch.tensor(state_feature_weights, dtype=torch.float32),
+            persistent=False,
+        )
+
+        if not self.output_std:
+            self.register_buffer(
+                "per_var_std",
+                self.diff_std / torch.sqrt(self.feature_weights),
+                persistent=False,
+            )
+
+        # Boundary/interior masks
+        da_boundary_mask = datastore.boundary_mask
+        boundary_mask = torch.tensor(
+            da_boundary_mask.values, dtype=torch.float32
+        ).unsqueeze(1)
+        self.register_buffer("boundary_mask", boundary_mask, persistent=False)
+        self.register_buffer(
+            "interior_mask", 1.0 - self.boundary_mask, persistent=False
+        )
+
+    @staticmethod
+    def expand_to_batch(x, batch_size):
+        """
+        Expand tensor with initial batch dimension.
+        """
+        return x.unsqueeze(0).expand(batch_size, -1, -1)
+
+    def predict_step(self, prev_state, prev_prev_state, forcing):
+        """
+        Predict one step ahead from previous states and forcing.
+        """
+        raise NotImplementedError("Subclasses must implement predict_step")

--- a/tests/test_models2_core.py
+++ b/tests/test_models2_core.py
@@ -1,0 +1,173 @@
+# Standard library
+from datetime import timedelta
+
+# Third-party
+import torch
+
+# First-party
+from neural_lam.models2.ar_forecaster import ARForecaster
+from neural_lam.models2.forecaster_module import ForecasterModule
+
+
+class MockDatastore:
+    """
+    Minimal datastore stub for ForecasterModule initialization.
+    """
+
+    step_length = timedelta(hours=1)
+
+
+class MockPredictor(torch.nn.Module):
+    """
+    Minimal one-step predictor used for models2 core tests.
+    """
+
+    def __init__(
+        self, output_std=False, num_grid_nodes=4, d_state=2, boundary_nodes=None
+    ):
+        super().__init__()
+        self.output_std = output_std
+        self.num_grid_nodes = num_grid_nodes
+        self.d_state = d_state
+
+        if boundary_nodes is None:
+            boundary_nodes = [0, num_grid_nodes - 1]
+
+        boundary_mask = torch.zeros(num_grid_nodes, 1, dtype=torch.float32)
+        boundary_mask[boundary_nodes] = 1.0
+        self.register_buffer("boundary_mask", boundary_mask, persistent=False)
+        self.register_buffer(
+            "interior_mask", 1.0 - boundary_mask, persistent=False
+        )
+
+        self.register_buffer(
+            "state_mean", torch.zeros(d_state), persistent=False
+        )
+        self.register_buffer("state_std", torch.ones(d_state), persistent=False)
+        self.register_buffer(
+            "per_var_std",
+            0.5 * torch.ones(d_state),
+            persistent=False,
+        )
+
+    def predict_step(self, prev_state, prev_prev_state, forcing):
+        _ = prev_prev_state
+        _ = forcing
+        pred_state = prev_state + 2.0
+        pred_std = torch.ones_like(pred_state) * 0.25 if self.output_std else None
+        return pred_state, pred_std
+
+
+class MockArgs:
+    """
+    Minimal args holder for ForecasterModule tests.
+    """
+
+    loss = "mse"
+    lr = 1e-3
+    restore_opt = False
+    n_example_pred = 0
+    val_steps_to_log = [1, 2, 3]
+    metrics_watch = []
+    var_leads_metrics_watch = {}
+
+
+def test_ar_forecaster_boundary_and_std_fallback():
+    predictor = MockPredictor(output_std=False, num_grid_nodes=4, d_state=1)
+    forecaster = ARForecaster(step_predictor=predictor)
+
+    # B=1, conditioning states are 10 and 20.
+    init_states = torch.tensor([[[[10.0], [10.0], [10.0], [10.0]], [[20.0], [20.0], [20.0], [20.0]]]])
+    forcing_features = torch.zeros(1, 2, 4, 3)
+
+    # Boundary values at each step should overwrite nodes 0 and 3.
+    true_states = torch.tensor(
+        [[[[100.0], [0.0], [0.0], [200.0]], [[300.0], [0.0], [0.0], [400.0]]]]
+    )
+
+    prediction, pred_std = forecaster(
+        init_states=init_states,
+        forcing_features=forcing_features,
+        true_states=true_states,
+    )
+
+    # Interior node values: step1 -> 22, step2 -> 24.
+    assert prediction.shape == (1, 2, 4, 1)
+    assert torch.allclose(prediction[0, 0, 1:3, 0], torch.tensor([22.0, 22.0]))
+    assert torch.allclose(prediction[0, 1, 1:3, 0], torch.tensor([24.0, 24.0]))
+    # Boundary nodes are overwritten from true_states.
+    assert torch.allclose(prediction[0, 0, [0, 3], 0], torch.tensor([100.0, 200.0]))
+    assert torch.allclose(prediction[0, 1, [0, 3], 0], torch.tensor([300.0, 400.0]))
+    # Matches ARModel contract for output_std=False.
+    assert torch.allclose(pred_std, predictor.per_var_std)
+
+
+def test_ar_forecaster_output_std_with_ensemble_shape():
+    predictor = MockPredictor(output_std=True, num_grid_nodes=3, d_state=2)
+    forecaster = ARForecaster(step_predictor=predictor)
+
+    init_states = torch.zeros(2, 2, 3, 2)
+    forcing_features = torch.zeros(2, 4, 3, 1)
+    true_states = torch.zeros(2, 4, 3, 2)
+
+    prediction, pred_std = forecaster(
+        init_states=init_states,
+        forcing_features=forcing_features,
+        true_states=true_states,
+        ensemble_size=3,
+    )
+
+    assert prediction.shape == (2, 3, 4, 3, 2)
+    assert pred_std.shape == (2, 3, 4, 3, 2)
+
+
+def test_forecaster_module_common_step_and_training_step():
+    predictor = MockPredictor(output_std=False, num_grid_nodes=4, d_state=1)
+    forecaster = ARForecaster(step_predictor=predictor)
+    module = ForecasterModule(
+        args=MockArgs(), forecaster=forecaster, datastore=MockDatastore()
+    )
+
+    init_states = torch.zeros(2, 2, 4, 1)
+    target_states = torch.ones(2, 3, 4, 1)
+    forcing_features = torch.zeros(2, 3, 4, 1)
+    batch_times = torch.zeros(2, 3, dtype=torch.long)
+    batch = (init_states, target_states, forcing_features, batch_times)
+
+    prediction, target, pred_std, times = module.common_step(batch)
+    assert prediction.shape == target.shape == (2, 3, 4, 1)
+    assert pred_std.shape == (1,)
+    assert torch.equal(times, batch_times)
+
+    batch_loss = module.training_step(batch)
+    assert batch_loss.ndim == 0
+    assert torch.isfinite(batch_loss)
+
+
+def test_forecaster_module_all_gather_cat_single_and_multi_device_sim():
+    class MockModule:
+        def all_gather(self, tensor, sync_grads=False):
+            _ = sync_grads
+            return tensor
+
+    single = MockModule()
+    single.all_gather_cat = ForecasterModule.all_gather_cat.__get__(
+        single, MockModule
+    )
+    tensor = torch.randn(4, 3, 5)
+    result = single.all_gather_cat(tensor)
+    assert result.shape == tensor.shape
+    assert torch.equal(result, tensor)
+
+    class MultiMockModule:
+        def all_gather(self, tensor, sync_grads=False):
+            _ = sync_grads
+            return torch.stack([tensor, tensor], dim=0)
+
+    multi = MultiMockModule()
+    multi.all_gather_cat = ForecasterModule.all_gather_cat.__get__(
+        multi, MultiMockModule
+    )
+    result = multi.all_gather_cat(tensor)
+    assert result.shape == (8, 3, 5)
+    assert torch.equal(result, torch.cat([tensor, tensor], dim=0))

--- a/tests/test_models2_parity.py
+++ b/tests/test_models2_parity.py
@@ -1,0 +1,286 @@
+# Standard library
+from pathlib import Path
+from types import SimpleNamespace
+
+# Third-party
+import torch
+
+# First-party
+from neural_lam import config as nlconfig
+from neural_lam.create_graph import create_graph_from_datastore
+from neural_lam.metrics import crps_loss
+from neural_lam.models.graph_lam import GraphLAM as LegacyGraphLAM
+from neural_lam.models2.ar_forecast_sampler import ARForecastSampler
+from neural_lam.models2.ar_forecaster import ARForecaster
+from neural_lam.models2.ensemble_forecaster_module import (
+    EnsembleForecasterModule,
+)
+from neural_lam.models2.forecaster_module import ForecasterModule
+from neural_lam.models2.graph_lam import GraphLAM as GraphLAMV2
+from neural_lam.weather_dataset import WeatherDataset
+from tests.conftest import init_datastore_example
+
+
+def _ensure_graph_exists(datastore, graph_name="1level"):
+    graph_dir_path = Path(datastore.root_path) / "graph" / graph_name
+    if not graph_dir_path.exists():
+        create_graph_from_datastore(
+            datastore=datastore,
+            output_root_path=str(graph_dir_path),
+            n_max_levels=1,
+        )
+
+
+def _build_config(datastore):
+    return nlconfig.NeuralLAMConfig(
+        datastore=nlconfig.DatastoreSelection(
+            kind=datastore.SHORT_NAME, config_path=datastore.root_path
+        )
+    )
+
+
+def _build_args(
+    *,
+    output_std=False,
+    ensemble_size=1,
+    graph_name="1level",
+):
+    return SimpleNamespace(
+        output_std=output_std,
+        loss="mse",
+        restore_opt=False,
+        n_example_pred=0,
+        graph=graph_name,
+        hidden_dim=4,
+        hidden_layers=1,
+        processor_layers=2,
+        mesh_aggr="sum",
+        lr=1.0e-3,
+        val_steps_to_log=[1, 2, 3],
+        metrics_watch=[],
+        var_leads_metrics_watch={},
+        num_past_forcing_steps=1,
+        num_future_forcing_steps=1,
+        ensemble_size=ensemble_size,
+    )
+
+
+def _build_batch(datastore, args, split="train", batch_size=2, ar_steps=3):
+    dataset = WeatherDataset(
+        datastore=datastore,
+        split=split,
+        ar_steps=ar_steps,
+        standardize=True,
+        num_past_forcing_steps=args.num_past_forcing_steps,
+        num_future_forcing_steps=args.num_future_forcing_steps,
+    )
+    samples = [dataset[i] for i in range(batch_size)]
+    batch = tuple(torch.stack([sample[i] for sample in samples]) for i in range(4))
+    return batch
+
+
+def _build_legacy_and_v2_models(datastore, args, config):
+    legacy = LegacyGraphLAM(args=args, config=config, datastore=datastore)
+    model_v2 = GraphLAMV2(args=args, config=config, datastore=datastore)
+
+    # Ensure both predictors have identical weights/buffers for parity checks.
+    load_result = model_v2.load_state_dict(legacy.state_dict(), strict=False)
+    assert len(load_result.missing_keys) == 0
+    assert len(load_result.unexpected_keys) == 0
+    return legacy, model_v2
+
+
+def test_models2_predict_step_parity_against_legacy_graphlam():
+    datastore = init_datastore_example("dummydata")
+    args = _build_args(output_std=False)
+    config = _build_config(datastore)
+    _ensure_graph_exists(datastore, graph_name=args.graph)
+
+    legacy, model_v2 = _build_legacy_and_v2_models(datastore, args, config)
+    batch = _build_batch(datastore, args, batch_size=1, ar_steps=2)
+    init_states, _, forcing_features, _ = batch
+
+    prev_prev_state = init_states[:, 0]
+    prev_state = init_states[:, 1]
+    forcing = forcing_features[:, 0]
+
+    with torch.no_grad():
+        legacy_pred, legacy_std = legacy.predict_step(
+            prev_state, prev_prev_state, forcing
+        )
+        v2_pred, v2_std = model_v2.predict_step(
+            prev_state, prev_prev_state, forcing
+        )
+
+    assert torch.allclose(legacy_pred, v2_pred, atol=1e-6, rtol=1e-5)
+    if legacy_std is None:
+        assert v2_std is None
+    else:
+        assert torch.allclose(legacy_std, v2_std, atol=1e-6, rtol=1e-5)
+
+
+def test_models2_ar_forecaster_unroll_parity_against_legacy_unroll():
+    datastore = init_datastore_example("dummydata")
+    args = _build_args(output_std=False, ensemble_size=1)
+    config = _build_config(datastore)
+    _ensure_graph_exists(datastore, graph_name=args.graph)
+
+    legacy, model_v2 = _build_legacy_and_v2_models(datastore, args, config)
+    init_states, target_states, forcing_features, _ = _build_batch(
+        datastore, args, batch_size=2, ar_steps=3
+    )
+
+    with torch.no_grad():
+        legacy_prediction, legacy_pred_std = legacy.unroll_prediction(
+            init_states, forcing_features, target_states
+        )
+        forecaster = ARForecaster(step_predictor=model_v2, args=args)
+        v2_prediction, v2_pred_std = forecaster(
+            init_states=init_states,
+            forcing_features=forcing_features,
+            true_states=target_states,
+        )
+
+    assert torch.allclose(
+        legacy_prediction, v2_prediction, atol=1e-6, rtol=1e-5
+    )
+    assert torch.allclose(legacy_pred_std, v2_pred_std, atol=1e-6, rtol=1e-5)
+
+
+def test_models2_forecaster_module_common_step_parity_against_legacy():
+    datastore = init_datastore_example("dummydata")
+    args = _build_args(output_std=False, ensemble_size=1)
+    config = _build_config(datastore)
+    _ensure_graph_exists(datastore, graph_name=args.graph)
+
+    legacy, model_v2 = _build_legacy_and_v2_models(datastore, args, config)
+    batch = _build_batch(datastore, args, batch_size=2, ar_steps=3)
+
+    with torch.no_grad():
+        legacy_prediction, legacy_target, legacy_std, legacy_times = (
+            legacy.common_step(batch)
+        )
+
+        forecaster = ARForecaster(step_predictor=model_v2, args=args)
+        module_v2 = ForecasterModule(
+            forecaster=forecaster,
+            args=args,
+            config=config,
+            datastore=datastore,
+        )
+        v2_prediction, v2_target, v2_std, v2_times = module_v2.common_step(batch)
+
+    assert torch.allclose(
+        legacy_prediction, v2_prediction, atol=1e-6, rtol=1e-5
+    )
+    assert torch.allclose(legacy_target, v2_target, atol=1e-6, rtol=1e-5)
+    assert torch.allclose(legacy_std, v2_std, atol=1e-6, rtol=1e-5)
+    assert torch.equal(legacy_times, v2_times)
+
+
+def test_ar_forecast_sampler_zero_noise_matches_repeated_deterministic_rollout():
+    datastore = init_datastore_example("dummydata")
+    args = _build_args(output_std=False, ensemble_size=3)
+    config = _build_config(datastore)
+    _ensure_graph_exists(datastore, graph_name=args.graph)
+
+    _, model_v2 = _build_legacy_and_v2_models(datastore, args, config)
+    init_states, target_states, forcing_features, _ = _build_batch(
+        datastore, args, batch_size=2, ar_steps=3
+    )
+
+    deterministic_forecaster = ARForecaster(step_predictor=model_v2, args=args)
+    sampler = ARForecastSampler(
+        step_predictor=model_v2,
+        args=args,
+        noise_std=0.0,
+    )
+
+    with torch.no_grad():
+        deterministic_prediction, deterministic_std = deterministic_forecaster(
+            init_states=init_states,
+            forcing_features=forcing_features,
+            true_states=target_states,
+        )
+        sampled_prediction, sampled_std = sampler(
+            init_states=init_states,
+            forcing_features=forcing_features,
+            true_states=target_states,
+            ensemble_size=args.ensemble_size,
+        )
+
+    assert sampled_prediction.shape[:2] == (
+        init_states.shape[0],
+        args.ensemble_size,
+    )
+    expected_prediction = deterministic_prediction.unsqueeze(1).expand_as(
+        sampled_prediction
+    )
+    assert torch.allclose(
+        sampled_prediction, expected_prediction, atol=1e-6, rtol=1e-5
+    )
+    # For deterministic predictor, std is per-variable tensor.
+    assert torch.allclose(sampled_std, deterministic_std, atol=1e-6, rtol=1e-5)
+
+
+def test_ensemble_forecaster_module_training_and_validation_metrics():
+    datastore = init_datastore_example("dummydata")
+    args = _build_args(output_std=False, ensemble_size=4)
+    config = _build_config(datastore)
+    _ensure_graph_exists(datastore, graph_name=args.graph)
+
+    _, model_v2 = _build_legacy_and_v2_models(datastore, args, config)
+    sampler = ARForecastSampler(
+        step_predictor=model_v2,
+        args=args,
+        noise_std=0.0,
+    )
+    module = EnsembleForecasterModule(
+        forecaster=sampler,
+        args=args,
+        config=config,
+        datastore=datastore,
+    )
+    batch = _build_batch(datastore, args, batch_size=2, ar_steps=3)
+
+    train_logs = {}
+    val_logs = {}
+
+    def _fake_log(name, value, **kwargs):
+        train_logs[name] = value.detach() if torch.is_tensor(value) else value
+        train_logs[f"{name}_kwargs"] = kwargs
+
+    def _fake_log_dict(log_dict, **kwargs):
+        for key, value in log_dict.items():
+            val_logs[key] = value.detach() if torch.is_tensor(value) else value
+        val_logs["kwargs"] = kwargs
+
+    module.log = _fake_log
+    module.log_dict = _fake_log_dict
+
+    train_loss = module.training_step(batch, batch_idx=0)
+    assert torch.isfinite(train_loss)
+    assert "train_loss" in train_logs
+    assert torch.isfinite(train_logs["train_loss"])
+
+    # Verify training CRPS computation matches explicit computation.
+    prediction, target_states, _, _ = module.common_step(batch)
+    mask = module.forecaster.step_predictor.interior_mask
+    expected_crps = torch.mean(
+        crps_loss(
+            prediction,
+            target_states,
+            mask=mask,
+            average_grid=False,
+            sum_vars=False,
+        )
+    )
+    assert torch.allclose(train_loss, expected_crps, atol=1e-6, rtol=1e-5)
+
+    module.validation_step(batch, batch_idx=0)
+    assert "val_crps" in val_logs
+    assert "val_spread" in val_logs
+    assert "val_error" in val_logs
+    assert torch.isfinite(val_logs["val_crps"])
+    assert torch.isfinite(val_logs["val_spread"])
+    assert torch.isfinite(val_logs["val_error"])


### PR DESCRIPTION
# Neural-LAM New Hierarchy (PR README)

This document summarizes the class hierarchy refactor introduced in `models2`, with a side-by-side view of the old and new architecture.

## Old Hierarchy (`neural_lam/models`)

```text
pytorch_lightning.LightningModule
└── ARModel
    └── BaseGraphModel
        ├── GraphLAM
        └── BaseHiGraphModel
            ├── HiLAM
            └── HiLAMParallel
```

### Characteristics

- `ARModel` combined training loop logic and autoregressive unroll logic.
- Graph-specific prediction (`predict_step`) was inherited through the same training class tree.
- Probabilistic ensemble generation and deterministic training logic were not separated into dedicated modules.

## New Hierarchy (`neural_lam/models2`)

```text
torch.nn.Module
└── StepPredictor
    └── BaseGraphModel
        ├── GraphLAM
        └── BaseHiGraphModel
            ├── HiLAM
            └── HiLAMParallel

torch.nn.Module
└── Forecaster
    └── ARForecaster
        └── ARForecastSampler

pytorch_lightning.LightningModule
└── ForecasterModule
    └── EnsembleForecasterModule
```

### Composition in `models2`

- `ARForecaster` owns autoregressive rollout and calls `step_predictor.predict_step(...)`.
- `ARForecastSampler` extends `ARForecaster` and generates batched ensemble trajectories.
- `ForecasterModule` wraps any `Forecaster` for train/val/test flow.
- `EnsembleForecasterModule` extends `ForecasterModule` and switches training/validation scoring to CRPS for ensembles.

## What Changed Structurally

- **Decoupled one-step neural prediction from rollout strategy**:
  - `StepPredictor` handles single-step state transition logic.
  - `Forecaster`/`ARForecaster` handles temporal unrolling.
- **Decoupled rollout from Lightning training orchestration**:
  - `ForecasterModule` handles optimization, logging, and evaluation loops.
- **Added probabilistic ensemble path**:
  - `ARForecastSampler` for stochastic ensemble generation.
  - `EnsembleForecasterModule` for CRPS-based scoring.

## Old-to-New Responsibility Mapping

| Old (`models`) | New (`models2`) | Responsibility |
|---|---|---|
| `ARModel.predict_step` (abstract) | `StepPredictor.predict_step` | One-step model update |
| `ARModel.unroll_prediction` | `ARForecaster.forward` | AR rollout over time |
| `ARModel.common_step` | `ForecasterModule.common_step` | Batch unpack + forecast call |
| `ARModel.training_step` | `ForecasterModule.training_step` / `EnsembleForecasterModule.training_step` | Loss calculation + logging |
| N/A (dedicated ensemble sampler) | `ARForecastSampler` | Ensemble member generation |

## Files Added/Updated in `models2`

- `step_predictor.py`
- `base_graph_model.py` (now based on `StepPredictor`)
- `base_hi_graph_model.py`
- `forecaster.py`
- `ar_forecaster.py`
- `ar_forecast_sampler.py` (+ compatibility re-export in `ar_forecast_sample.py`)
- `forecaster_module.py`
- `ensemble_forecaster_module.py`

## Metrics Update

- Added `crps_loss` in `neural_lam/metrics.py` for sample-based ensemble CRPS evaluation.

## Development Note (In Progress)

- Current parity testing uses `noise_std=0.0` in `tests/test_models2_parity.py` to make CRPS comparisons deterministic across repeated forward passes.
- This is a temporary testing choice only; ensemble sampling is intended to run with non-zero noise (`noise_std > 0`) and this part is still under active development.
