### PR TITLE
Add missing NumPy-style docstrings to graph models(issue #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add missing NumPy-style docstrings to `BaseGraphModel`, `GraphLAM`, and `HiLAM` to allow automatic API documentation generation with Sphinx. @[yourusername]
+
 - Expose `--wandb_id` CLI argument to allow resuming an existing W&B run by
   ID. When provided, `resume="allow"` is set automatically so the same job
   script works for both the initial submission and all resubmissions, making

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -13,6 +13,15 @@ class BaseGraphModel(ARModel):
     """
     Base (abstract) class for graph-based models building on
     the encode-process-decode idea.
+
+    Parameters
+    ----------
+    args : Namespace
+        Command-line arguments containing model hyper-parameters and configuration.
+    config : NeuralLAMConfig
+        Configuration object containing training and dataset settings.
+    datastore : BaseDatastore
+        Datastore object providing access to weather data and spatial features.
     """
 
     def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
@@ -86,7 +95,7 @@ class BaseGraphModel(ARModel):
         self, config: NeuralLAMConfig, datastore: BaseDatastore
     ):
         """
-        Prepare parameters for clamping predicted values to valid range
+        Prepare parameters for clamping predicted values to valid range.
         """
 
         # Read configs
@@ -219,18 +228,28 @@ class BaseGraphModel(ARModel):
 
     def get_clamped_new_state(self, state_delta, prev_state):
         """
-        Clamp prediction to valid range supplied in config
-        Returns the clamped new state after adding delta to original state
+        Clamp prediction to valid range supplied in config.
+        
+        Returns the clamped new state after adding delta to original state.
 
         Instead of the new state being computed as
         $X_{t+1} = X_t + \\delta = X_t + model(\\{X_t,X_{t-1},...\\}, forcing)$
         The clamped values will be
         $f(f^{-1}(X_t) + model(\\{X_t, X_{t-1},... \\}, forcing))$
         Which means the model will learn to output values in the range of the
-        inverse clamping function
+        inverse clamping function.
 
-        state_delta: (B, num_grid_nodes, feature_dim)
-        prev_state: (B, num_grid_nodes, feature_dim)
+        Parameters
+        ----------
+        state_delta : torch.Tensor
+            The predicted change in state, with shape `(B, num_grid_nodes, feature_dim)`.
+        prev_state : torch.Tensor
+            The previous state $X_t$, with shape `(B, num_grid_nodes, feature_dim)`.
+
+        Returns
+        -------
+        torch.Tensor
+            The new, clamped state with shape `(B, num_grid_nodes, feature_dim)`.
         """
 
         # Assign new state, but overwrite clamped values of each type later
@@ -267,34 +286,66 @@ class BaseGraphModel(ARModel):
 
     def get_num_mesh(self):
         """
-        Compute number of mesh nodes from loaded features,
-        and number of mesh nodes that should be ignored in encoding/decoding
+        Compute number of mesh nodes from loaded features.
+
+        Returns
+        -------
+        int
+            Number of mesh nodes from loaded features.
+        int
+            Number of mesh nodes that should be ignored in encoding/decoding.
         """
         raise NotImplementedError("get_num_mesh not implemented")
 
     def embedd_mesh_nodes(self):
         """
-        Embed static mesh features
-        Returns tensor of shape (num_mesh_nodes, d_h)
+        Embed static mesh features.
+
+        Returns
+        -------
+        torch.Tensor
+            A tensor of embedded mesh features with shape `(num_mesh_nodes, d_h)`.
         """
         raise NotImplementedError("embedd_mesh_nodes not implemented")
 
     def process_step(self, mesh_rep):
         """
-        Process step of embedd-process-decode framework
-        Processes the representation on the mesh, possible in multiple steps
+        Process step of encode-process-decode framework.
+        
+        Processes the representation on the mesh, possibly in multiple steps.
 
-        mesh_rep: has shape (B, num_mesh_nodes, d_h)
-        Returns mesh_rep: (B, num_mesh_nodes, d_h)
+        Parameters
+        ----------
+        mesh_rep : torch.Tensor
+            The representation of data on the mesh nodes. Expected shape is 
+            `(B, num_mesh_nodes, d_h)`.
+
+        Returns
+        -------
+        torch.Tensor
+            The processed mesh representation with shape `(B, num_mesh_nodes, d_h)`.
         """
         raise NotImplementedError("process_step not implemented")
 
     def predict_step(self, prev_state, prev_prev_state, forcing):
         """
-        Step state one step ahead using prediction model, X_{t-1}, X_t -> X_t+1
-        prev_state: (B, num_grid_nodes, feature_dim), X_t
-        prev_prev_state: (B, num_grid_nodes, feature_dim), X_{t-1}
-        forcing: (B, num_grid_nodes, forcing_dim)
+        Step state one step ahead using prediction model: $X_{t-1}, X_t \\rightarrow X_{t+1}$.
+
+        Parameters
+        ----------
+        prev_state : torch.Tensor
+            The previous state $X_t$, with shape `(B, num_grid_nodes, feature_dim)`.
+        prev_prev_state : torch.Tensor
+            The state before the previous one $X_{t-1}$, with shape `(B, num_grid_nodes, feature_dim)`.
+        forcing : torch.Tensor
+            The forcing data for the step, with shape `(B, num_grid_nodes, forcing_dim)`.
+
+        Returns
+        -------
+        tuple of torch.Tensor or None
+            A tuple containing:
+            - The newly predicted state $X_{t+1}$ with shape `(B, num_grid_nodes, feature_dim)`.
+            - The predicted standard deviation (if applicable) with shape `(B, num_grid_nodes, feature_dim)`, or `None`.
         """
         batch_size = prev_state.shape[0]
 

--- a/neural_lam/models/graph_lam.py
+++ b/neural_lam/models/graph_lam.py
@@ -12,9 +12,18 @@ from .base_graph_model import BaseGraphModel
 class GraphLAM(BaseGraphModel):
     """
     Full graph-based LAM model that can be used with different
-    (non-hierarchical )graphs. Mainly based on GraphCast, but the model from
+    (non-hierarchical) graphs. Mainly based on GraphCast, but the model from
     Keisler (2022) is almost identical. Used for GC-LAM and L1-LAM in
     Oskarsson et al. (2023).
+
+    Parameters
+    ----------
+    args : Namespace
+        Command-line arguments containing model hyper-parameters and configuration.
+    config : NeuralLAMConfig
+        Configuration object containing training and dataset settings.
+    datastore : BaseDatastore
+        Datastore object providing access to weather data and spatial features.
     """
 
     def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
@@ -58,25 +67,44 @@ class GraphLAM(BaseGraphModel):
 
     def get_num_mesh(self):
         """
-        Compute number of mesh nodes from loaded features,
-        and number of mesh nodes that should be ignored in encoding/decoding
+        Compute number of mesh nodes from loaded features.
+
+        Returns
+        -------
+        int
+            Number of mesh nodes from loaded features.
+        int
+            Number of mesh nodes that should be ignored in encoding/decoding.
         """
         return self.mesh_static_features.shape[0], 0
 
     def embedd_mesh_nodes(self):
         """
-        Embed static mesh features
-        Returns tensor of shape (N_mesh, d_h)
+        Embed static mesh features.
+
+        Returns
+        -------
+        torch.Tensor
+            Embedded static mesh features with shape `(N_mesh, d_h)`.
         """
         return self.mesh_embedder(self.mesh_static_features)  # (N_mesh, d_h)
 
     def process_step(self, mesh_rep):
         """
-        Process step of embedd-process-decode framework
-        Processes the representation on the mesh, possible in multiple steps
+        Process step of encode-process-decode framework.
+        
+        Processes the representation on the mesh.
 
-        mesh_rep: has shape (B, N_mesh, d_h)
-        Returns mesh_rep: (B, N_mesh, d_h)
+        Parameters
+        ----------
+        mesh_rep : torch.Tensor
+            The representation of data on the mesh nodes. Expected shape is 
+            `(B, N_mesh, d_h)`.
+
+        Returns
+        -------
+        torch.Tensor
+            The processed mesh representation with shape `(B, N_mesh, d_h)`.
         """
         # Embed m2m here first
         batch_size = mesh_rep.shape[0]

--- a/neural_lam/models/hi_lam.py
+++ b/neural_lam/models/hi_lam.py
@@ -12,7 +12,16 @@ class HiLAM(BaseHiGraphModel):
     """
     Hierarchical graph model with message passing that goes sequentially down
     and up the hierarchy during processing.
-    The Hi-LAM model from Oskarsson et al. (2023)
+    The Hi-LAM model from Oskarsson et al. (2023).
+
+    Parameters
+    ----------
+    args : Namespace
+        Command-line arguments containing model hyper-parameters and configuration.
+    config : NeuralLAMConfig
+        Configuration object containing training and dataset settings.
+    datastore : BaseDatastore
+        Datastore object providing access to weather data and spatial features.
     """
 
     def __init__(self, args, config: NeuralLAMConfig, datastore: BaseDatastore):
@@ -37,6 +46,16 @@ class HiLAM(BaseHiGraphModel):
     def make_same_gnns(self, args):
         """
         Make intra-level GNNs.
+
+        Parameters
+        ----------
+        args : Namespace
+            Command-line arguments with configuration for GNNs.
+
+        Returns
+        -------
+        nn.ModuleList
+            A list of GNN interaction networks for the same level.
         """
         return nn.ModuleList(
             [
@@ -52,6 +71,16 @@ class HiLAM(BaseHiGraphModel):
     def make_up_gnns(self, args):
         """
         Make GNNs for processing steps up through the hierarchy.
+
+        Parameters
+        ----------
+        args : Namespace
+            Command-line arguments with configuration for GNNs.
+
+        Returns
+        -------
+        nn.ModuleList
+            A list of GNN interaction networks for up steps.
         """
         return nn.ModuleList(
             [
@@ -67,6 +96,16 @@ class HiLAM(BaseHiGraphModel):
     def make_down_gnns(self, args):
         """
         Make GNNs for processing steps down through the hierarchy.
+
+        Parameters
+        ----------
+        args : Namespace
+            Command-line arguments with configuration for GNNs.
+
+        Returns
+        -------
+        nn.ModuleList
+            A list of GNN interaction networks for down steps.
         """
         return nn.ModuleList(
             [
@@ -90,6 +129,25 @@ class HiLAM(BaseHiGraphModel):
         """
         Run down-part of vertical processing, sequentially alternating between
         processing using down edges and same-level edges.
+
+        Parameters
+        ----------
+        mesh_rep_levels : list of torch.Tensor
+            Node representations for each level.
+        mesh_same_rep : list of torch.Tensor
+            Same-level edge representations.
+        mesh_down_rep : list of torch.Tensor
+            Down-edge representations.
+        down_gnns : nn.ModuleList
+            GNN models for processing down-edges.
+        same_gnns : nn.ModuleList
+            GNN models for processing same-level edges.
+
+        Returns
+        -------
+        tuple
+            A tuple containing `(mesh_rep_levels, mesh_same_rep, mesh_down_rep)` 
+            after processing.
         """
         # Run same level processing on level L
         mesh_rep_levels[-1], mesh_same_rep[-1] = same_gnns[-1](
@@ -129,6 +187,25 @@ class HiLAM(BaseHiGraphModel):
         """
         Run up-part of vertical processing, sequentially alternating between
         processing using up edges and same-level edges.
+
+        Parameters
+        ----------
+        mesh_rep_levels : list of torch.Tensor
+            Node representations for each level.
+        mesh_same_rep : list of torch.Tensor
+            Same-level edge representations.
+        mesh_up_rep : list of torch.Tensor
+            Up-edge representations.
+        up_gnns : nn.ModuleList
+            GNN models for processing up-edges.
+        same_gnns : nn.ModuleList
+            GNN models for processing same-level edges.
+
+        Returns
+        -------
+        tuple
+            A tuple containing `(mesh_rep_levels, mesh_same_rep, mesh_up_rep)` 
+            after processing.
         """
 
         # Run same level processing on level 0
@@ -169,14 +246,21 @@ class HiLAM(BaseHiGraphModel):
         Internal processor step of hierarchical graph models.
         Between mesh init and read out.
 
-        Each input is list with representations, each with shape
+        Parameters
+        ----------
+        mesh_rep_levels : list of torch.Tensor 
+            Node representations for each level, each with shape `(B, N_mesh[l], d_h)`.
+        mesh_same_rep : list of torch.Tensor
+            Same-level edge representations, each with shape `(B, M_same[l], d_h)`.
+        mesh_up_rep : list of torch.Tensor
+            Up-edge representations, each with shape `(B, M_up[l -> l+1], d_h)`.
+        mesh_down_rep : list of torch.Tensor
+            Down-edge representations, each with shape `(B, M_down[l <- l+1], d_h)`.
 
-        mesh_rep_levels: (B, N_mesh[l], d_h)
-        mesh_same_rep: (B, M_same[l], d_h)
-        mesh_up_rep: (B, M_up[l -> l+1], d_h)
-        mesh_down_rep: (B, M_down[l <- l+1], d_h)
-
-        Returns same lists
+        Returns
+        -------
+        tuple
+            A tuple `(mesh_rep_levels, mesh_same_rep, mesh_up_rep, mesh_down_rep)`.
         """
         for down_gnns, down_same_gnns, up_gnns, up_same_gnns in zip(
             self.mesh_down_gnns,


### PR DESCRIPTION
Added missing NumPy-style docstrings to BaseGraphModel, GraphLAM, and HiLAM core models so that Sphinx autodoc and napoleon can automatically generate API reference pages.