### PR TITLE
Fix: prevent variance underflow causing NaN losses

### DIFF
--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -351,7 +351,9 @@ class BaseGraphModel(ARModel):
             # NOTE: The predicted std. is not scaled in any way here
             # linter for some reason does not think softplus is callable
             # pylint: disable-next=not-callable
+            eps = 1e-6
             pred_std = torch.nn.functional.softplus(pred_std_raw)
+            pred_std = torch.clamp(pred_std, min=eps)
         else:
             pred_delta_mean = net_output
             pred_std = None


### PR DESCRIPTION
Problem
Softplus activation can produce zero values for very negative inputs, leading to division-by-zero and NaN losses during training.

 Solution
Added a clamp (min=1e-6) to the predicted standard deviation to ensure numerical stability.

Impact
- Prevents NaN crashes
- Ensures stable probabilistic training