### PR TITLE
Add graph edge index bounds checks in graph creation tests

### DIFF
--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -13,6 +13,71 @@ from neural_lam.datastore.base import BaseRegularGridDatastore
 from tests.conftest import init_datastore_example
 
 
+def _mesh_nodes_per_level(mesh_features: list) -> list[int]:
+    """Number of mesh nodes at each level (matches ``mesh_features.pt`` layout)."""
+    return [int(t.shape[0]) for t in mesh_features]
+
+
+def _assert_edge_index_in_range(
+    edge_index: torch.Tensor,
+    *,
+    n_nodes: int,
+    name: str,
+) -> None:
+    """All entries must be valid node ids in ``[0, n_nodes)``."""
+    assert edge_index.numel() > 0, f"{name}: empty edge_index"
+    assert torch.all(edge_index >= 0), f"{name}: negative node index"
+    assert torch.all(edge_index < n_nodes), (
+        f"{name}: node index out of range (max={edge_index.max().item()}, "
+        f"n_nodes={n_nodes})"
+    )
+
+
+def _assert_m2m_edge_indices_per_level(
+    m2m_indices: list,
+    mesh_features: list,
+) -> None:
+    """m2m edges at level ``l`` use global mesh ids for that level's slice."""
+    sizes = _mesh_nodes_per_level(mesh_features)
+    assert len(m2m_indices) == len(sizes), "m2m levels vs mesh_features mismatch"
+    start = 0
+    for level, (ei, n_l) in enumerate(zip(m2m_indices, sizes)):
+        _assert_edge_index_in_range(
+            ei,
+            n_nodes=start + n_l,
+            name=f"m2m_edge_index level {level}",
+        )
+        # Stronger: indices stay inside this level's block
+        assert torch.all(ei >= start), (
+            f"m2m level {level}: index below start {start} "
+            f"(min={ei.min().item()})"
+        )
+        assert torch.all(ei < start + n_l), (
+            f"m2m level {level}: index above block end {start + n_l - 1}"
+        )
+        start += n_l
+
+
+def _assert_hierarchical_mesh_up_down_in_range(
+    mesh_up: list,
+    mesh_down: list,
+    n_mesh_total: int,
+) -> None:
+    """Up/down edges only reference global mesh node ids."""
+    assert len(mesh_up) == len(mesh_down)
+    for i, (up_ei, down_ei) in enumerate(zip(mesh_up, mesh_down)):
+        _assert_edge_index_in_range(
+            up_ei,
+            n_nodes=n_mesh_total,
+            name=f"mesh_up_edge_index[{i}]",
+        )
+        _assert_edge_index_in_range(
+            down_ei,
+            n_nodes=n_mesh_total,
+            name=f"mesh_down_edge_index[{i}]",
+        )
+
+
 @pytest.mark.parametrize("graph_name", ["1level", "multiscale", "hierarchical"])
 @pytest.mark.parametrize("datastore_name", DATASTORES.keys())
 def test_graph_creation(datastore_name, graph_name):
@@ -117,3 +182,42 @@ def test_graph_creation(datastore_name, graph_name):
                         assert r.shape[0] == 2  # adjacency matrix uses two rows
                     elif file_id.endswith("_features"):
                         assert r.shape[1] == d_features
+
+        # --- Edge indices must reference valid node ids (grid+mesh or mesh-only)
+        xy = datastore.get_xy(category="state", stacked=False)
+        n_grid = int(xy.shape[0] * xy.shape[1])
+
+        mesh_pos_list = torch.load(
+            graph_dir_path / "mesh_features.pt", weights_only=True
+        )
+        n_mesh_total = sum(int(t.shape[0]) for t in mesh_pos_list)
+        n_bipartite = n_grid + n_mesh_total
+
+        g2m_ei = torch.load(
+            graph_dir_path / "g2m_edge_index.pt", weights_only=True
+        )
+        m2g_ei = torch.load(
+            graph_dir_path / "m2g_edge_index.pt", weights_only=True
+        )
+        m2m_ei_list = torch.load(
+            graph_dir_path / "m2m_edge_index.pt", weights_only=True
+        )
+
+        _assert_edge_index_in_range(
+            g2m_ei, n_nodes=n_bipartite, name="g2m_edge_index"
+        )
+        _assert_edge_index_in_range(
+            m2g_ei, n_nodes=n_bipartite, name="m2g_edge_index"
+        )
+        _assert_m2m_edge_indices_per_level(m2m_ei_list, mesh_pos_list)
+
+        if hierarchical:
+            mesh_up_list = torch.load(
+                graph_dir_path / "mesh_up_edge_index.pt", weights_only=True
+            )
+            mesh_down_list = torch.load(
+                graph_dir_path / "mesh_down_edge_index.pt", weights_only=True
+            )
+            _assert_hierarchical_mesh_up_down_in_range(
+                mesh_up_list, mesh_down_list, n_mesh_total
+            )


### PR DESCRIPTION
## Describe your changes

- Extend `tests/test_graph_creation.py` with helpers and assertions so that, after `create_graph_from_datastore` runs on the example regular-grid datastores, every saved `edge_index` tensor uses **in-range node ids**:
  - **g2m / m2g:** combined grid + mesh vertex set (`n_grid + n_mesh_total`).
  - **m2m:** per-level tensors must stay inside that level’s **global mesh index block**, consistent with `mesh_features.pt` lengths.
  - **Hierarchical only:** **mesh_up / mesh_down** tensors must reference ids in `[0, n_mesh_total)`.

**Motivation:** Invalid indices often show up only at training time. Catching out-of-bounds (or inconsistent-level) indices right after graph generation makes graph bugs faster to diagnose and complements eventual cross-file edge-count work (e.g. #380).

**Dependencies:** None — only `torch` / existing test harness.

## Issue Link

closes #534

## Type of change

*(test-only; pick what maintainers prefer — often CHANGELOG under **maintenance**)*

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes *(N/A — tests only; README update is #535)*
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)). *(Suggested title: **Add graph edge index bounds checks in graph creation tests**)* 
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

*(Suggested one-liner under **maintenance**: “Add bounds checks for saved graph `edge_index` tensors in `test_graph_creation`.”)*

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.