### PR TITLE
Add input validation and minor cleanup

### DIFF
--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -71,6 +71,10 @@ def wmse(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
     depending on reduction arguments.
     """
+    assert pred.shape == target.shape, (
+        f"pred and target must have the same shape, "
+        f"got {pred.shape} and {target.shape}"
+    )
     entry_mse = torch.nn.functional.mse_loss(
         pred, target, reduction="none"
     )  # (..., N, d_state)
@@ -126,6 +130,10 @@ def wmae(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     metric_val: One of (...,), (..., d_state), (..., N), (..., N, d_state),
     depending on reduction arguments.
     """
+    assert pred.shape == target.shape, (
+        f"pred and target must have the same shape, "
+        f"got {pred.shape} and {target.shape}"
+    )
     entry_mae = torch.nn.functional.l1_loss(
         pred, target, reduction="none"
     )  # (..., N, d_state)
@@ -182,6 +190,9 @@ def nll(pred, target, pred_std, mask=None, average_grid=True, sum_vars=True):
     depending on reduction arguments.
     """
     # Broadcast pred_std if shaped (d_state,), done internally in Normal class
+    # Clamp from below to prevent the distribution from collapsing to a spike,
+    # which causes log_prob to blow up
+    pred_std = pred_std.clamp(min=1e-6)
     dist = torch.distributions.Normal(pred, pred_std)  # (..., N, d_state)
     entry_nll = -dist.log_prob(target)  # (..., N, d_state)
 

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -703,38 +703,26 @@ class WeatherDataModule(pl.LightningDataModule):
                 load_single_member=self.load_single_member,
             )
 
-    def train_dataloader(self):
-        """Load train dataset."""
+    def _make_dataloader(self, dataset, shuffle: bool):
+        """Construct a DataLoader with shared configuration."""
         return torch.utils.data.DataLoader(
-            self.train_dataset,
+            dataset,
             batch_size=self.batch_size,
             num_workers=self.num_workers,
-            shuffle=True,
+            shuffle=shuffle,
             multiprocessing_context=self.multiprocessing_context,
             persistent_workers=self.num_workers > 0,
             pin_memory=torch.cuda.is_available(),
         )
+
+    def train_dataloader(self):
+        """Load train dataset."""
+        return self._make_dataloader(self.train_dataset, shuffle=True)
 
     def val_dataloader(self):
         """Load validation dataset."""
-        return torch.utils.data.DataLoader(
-            self.val_dataset,
-            batch_size=self.batch_size,
-            num_workers=self.num_workers,
-            shuffle=False,
-            multiprocessing_context=self.multiprocessing_context,
-            persistent_workers=self.num_workers > 0,
-            pin_memory=torch.cuda.is_available(),
-        )
+        return self._make_dataloader(self.val_dataset, shuffle=False)
 
     def test_dataloader(self):
         """Load test dataset."""
-        return torch.utils.data.DataLoader(
-            self.test_dataset,
-            batch_size=self.batch_size,
-            num_workers=self.num_workers,
-            shuffle=False,
-            multiprocessing_context=self.multiprocessing_context,
-            persistent_workers=self.num_workers > 0,
-            pin_memory=torch.cuda.is_available(),
-        )
+        return self._make_dataloader(self.test_dataset, shuffle=False)


### PR DESCRIPTION
wmse and wmae: assert pred and target shapes match before computation, surfacing mismatches early with a clear error
nll: clamp pred_std from below (min=1e-6) to prevent the Gaussian distribution from collapsing to a spike and blowing up log_prob
WeatherDataModule: extract _make_dataloader helper to deduplicate the shared 7-argument DataLoader configuration across train_dataloader, val_dataloader, and test_dataloader
