### PR TITLE
Fix/create dataarray category feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add missing bounds check in `test_step` to prevent `IndexError` when `val_steps_to_log` exceeds prediction steps [\#220](https://github.com/mllam/neural-lam/pull/220) @santhil-cyber
 
+- Fix `create_dataarray_from_tensor` in `WeatherDataset` hardcoding `.state_feature` coordinate regardless of `category`, causing `AttributeError` for `forcing` and `static` categories; also fix missing f-string prefix in error message
+
 ### Maintenance
 
 - Add comprehensive type hints to all functions and class methods in `utils.py` [\#620](https://github.com/mllam/neural-lam/pull/620) @GiGiKoneti

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix division-by-zero in `create_graph` mesh position normalization when `pos_max` is zero [\#594](https://github.com/mllam/neural-lam/issues/594) @Pran-jal25
+
 - Fix `AssertionError` in `aggregate_and_plot_metrics` when using `--metrics_watch` flags by using `isinstance` dispatch for figure vs scalar logging [\#303](https://github.com/mllam/neural-lam/pull/303) @AftAb-25
 
 - Resolve `xarray` `FacetGrid` `DeprecationWarning` in `plot_example.py` by using a compatibility shim [\#482](https://github.com/mllam/neural-lam/pull/482) @sohampatil01-svg

--- a/neural_lam/create_graph.py
+++ b/neural_lam/create_graph.py
@@ -415,8 +415,10 @@ def create_graph(
     # Save m2m edges
     save_edges_list(m2m_graphs, "m2m", graph_dir_path)
 
-    # Divide mesh node pos by max coordinate of grid cell
-    mesh_pos = [pos / pos_max for pos in mesh_pos]
+    # Divide mesh node pos by max coordinate of grid cell.
+    # Guard against degenerate grids where pos_max is zero to avoid NaN/Inf.
+    if pos_max > 0:
+        mesh_pos = [pos / pos_max for pos in mesh_pos]
 
     # Save mesh positions
     torch.save(

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -587,7 +587,7 @@ class WeatherDataset(torch.utils.data.Dataset):
             if _is_listlike(time):
                 raise ValueError(
                     "Expected a single time for a 2D tensor with assumed "
-                    "dimensions (grid_index, {category}_feature), but got "
+                    f"dimensions (grid_index, {category}_feature), but got "
                     f"{len(time)} times"  # type: ignore
                 )
         elif len(tensor.shape) == 3:
@@ -607,7 +607,7 @@ class WeatherDataset(torch.utils.data.Dataset):
 
         da_datastore_state = getattr(self, f"da_{category}")
         da_grid_index = da_datastore_state.grid_index
-        da_state_feature = da_datastore_state.state_feature
+        da_state_feature = da_datastore_state[f"{category}_feature"]
 
         coords = {
             f"{category}_feature": da_state_feature,


### PR DESCRIPTION
WeatherDataset.create_dataarray_from_tensor had 2 bugs:

Wrong coordinate access — the feature coordinate was hardcoded as .state_feature regardless of the category argument. Calling the method with category="forcing" or category="static" raised AttributeError: 'DataArray' object has no attribute 'state_feature'. Fixed by using da_datastore_state[f"{category}_feature"] so the correct coordinate (forcing_feature, static_feature, etc.) is accessed dynamically.

Missing f-string prefix — the error message for the 2D tensor validation case was a plain string "dimensions (grid_index, {category}_feature), but got ", so {category} appeared literally in the message instead of being interpolated. Added the f prefix.

No behaviour change for the existing category="state" path.