### PR TITLE
Fix zero-grid mesh normalization

### DIFF
--- a/neural_lam/create_graph.py
+++ b/neural_lam/create_graph.py
@@ -415,8 +415,16 @@ def create_graph(
     # Save m2m edges
     save_edges_list(m2m_graphs, "m2m", graph_dir_path)
 
-    # Divide mesh node pos by max coordinate of grid cell
-    mesh_pos = [pos / pos_max for pos in mesh_pos]
+    # Divide mesh node pos by max coordinate of grid cell. Degenerate test
+    # grids can have all coordinates at the origin, where normalization would
+    # otherwise create NaN values from 0 / 0.
+    if pos_max > 0:
+        mesh_pos = [pos / pos_max for pos in mesh_pos]
+    else:
+        logger.warning(
+            "Skipping mesh position normalization because the maximum grid "
+            "coordinate is zero."
+        )
 
     # Save mesh positions
     torch.save(

--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -3,11 +3,12 @@ import tempfile
 from pathlib import Path
 
 # Third-party
+import numpy as np
 import pytest
 import torch
 
 # First-party
-from neural_lam.create_graph import create_graph_from_datastore
+from neural_lam.create_graph import create_graph, create_graph_from_datastore
 from neural_lam.datastore import DATASTORES
 from neural_lam.datastore.base import BaseRegularGridDatastore
 from tests.conftest import init_datastore_example
@@ -117,3 +118,31 @@ def test_graph_creation(datastore_name, graph_name):
                         assert r.shape[0] == 2  # adjacency matrix uses two rows
                     elif file_id.endswith("_features"):
                         assert r.shape[1] == d_features
+
+
+@pytest.mark.parametrize("hierarchical", [False, True])
+def test_graph_creation_zero_grid_positions_are_finite(hierarchical):
+    """Check that zero-centered degenerate grids do not create NaN features."""
+    xy = np.zeros((9, 9, 2), dtype=np.float32)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        graph_dir_path = Path(tmpdir) / "graph" / "zero-grid"
+
+        create_graph(
+            graph_dir_path=str(graph_dir_path),
+            xy=xy,
+            hierarchical=hierarchical,
+            n_max_levels=1,
+        )
+
+        feature_files = [
+            "mesh_features.pt",
+            "m2m_features.pt",
+            "g2m_features.pt",
+            "m2g_features.pt",
+        ]
+        for file_name in feature_files:
+            result = torch.load(graph_dir_path / file_name, weights_only=True)
+            tensors = result if isinstance(result, list) else [result]
+            for tensor in tensors:
+                assert torch.isfinite(tensor).all()


### PR DESCRIPTION
## Describe your changes

This fixes graph creation for degenerate grids whose coordinates are all at the origin. In that case `pos_max` is zero, so normalizing mesh positions with `pos / pos_max` writes NaN values into `mesh_features.pt`.

The change keeps existing normalization for normal grids and skips only the invalid zero-denominator case, leaving already-zero mesh positions unchanged. It also adds a regression test that creates hierarchical and non-hierarchical zero-coordinate graphs and checks all saved graph feature tensors are finite.

No new dependencies are required.

## Issue Link

Fixes #594

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Verification

- `python -m compileall -q neural_lam/create_graph.py tests/test_graph_creation.py`
- `python -m black --check neural_lam/create_graph.py tests/test_graph_creation.py`
- `python -m isort --check-only neural_lam/create_graph.py tests/test_graph_creation.py`
- `git diff --check`
- Direct regression check for zero-grid graph features in hierarchical and non-hierarchical modes
- Direct regression check for regular-grid mesh normalization

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section reflecting type of change.