### PR TITLE
fix: resolve torch version from target wheel index in CI

### DIFF
--- a/.github/workflows/install-and-test.yml
+++ b/.github/workflows/install-and-test.yml
@@ -62,9 +62,20 @@ jobs:
       - name: Determine PyTorch version for neural-lam (using pip dry-run)
         if: matrix.package_manager == 'pip'
         run: |
-          TORCH_VERSION=$(python -m pip install --dry-run "." | grep "Would install" | grep -o 'torch-[0-9.]*' | awk -F'-' '{print $2}' | tail -n 1)
-          echo "Torch version detected: $TORCH_VERSION"
-          echo "TORCH_VERSION=$TORCH_VERSION" >> $GITHUB_ENV
+          # Read the lower-bound torch version directly from pyproject.toml so we
+          # are not affected by PyPI resolving a version that the target wheel index
+          # (e.g. cu128) does not yet carry.
+          MIN_VERSION=$(grep -o 'torch>=[0-9.]*' pyproject.toml | grep -o '[0-9.]*$')
+          echo "Minimum torch version required: ${MIN_VERSION}"
+          # Find the latest version satisfying that minimum in the target index.
+          # This returns the highest version present in the wheel index (e.g. cu128)
+          # rather than the highest version on PyPI.
+          TORCH_VERSION=$(python -m pip install --dry-run "torch>=${MIN_VERSION}" \
+            --index-url ${{ matrix.torch_index }} 2>&1 \
+            | grep "Would install" | grep -o 'torch-[0-9.]*' \
+            | awk -F'-' '{print $2}' | tail -n 1)
+          echo "Torch version to install: ${TORCH_VERSION}"
+          echo "TORCH_VERSION=${TORCH_VERSION}" >> $GITHUB_ENV
 
       - name: Install PyTorch
         if : matrix.package_manager != 'uv'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Maintenance
 
+- Fix GPU CI torch version resolution to query the target wheel index instead of PyPI [\#639](https://github.com/mllam/neural-lam/pull/639) @Sir-Sloth-The-Lazy
+
 - Add comprehensive type hints to all functions and class methods in `utils.py` [\#620](https://github.com/mllam/neural-lam/pull/620) @GiGiKoneti
 
 - Add probabilistic objective regression coverage for weighted losses and `pred_std` broadcasting semantics [\#504](https://github.com/mllam/neural-lam/pull/504) @kshirajahere


### PR DESCRIPTION
## Describe your changes

The GPU CI job fails when PyPI carries a torch release that the cu128 wheel index does not yet have. The existing "Determine PyTorch version" step runs `pip install --dry-run "."` which queries **PyPI** and resolves the latest version (e.g. `2.12.0`). The subsequent install step then tries to fetch that exact version from the cu128 index, which only carries up to `2.11.0+cu128`, causing the error:

```
ERROR: Could not find a version that satisfies the requirement torch==2.12.0
(from versions: 2.7.0+cu128 ... 2.11.0+cu128)
```

This fix changes the version detection to:
1. Read the **lower-bound** torch constraint directly from `pyproject.toml` (`torch>=2.3.0`), avoiding PyPI resolution entirely.
2. Run a dry-run against the **target matrix wheel index** to find the highest version available there (e.g. `2.11.0` from cu128, or the current latest from the CPU index).

The resolved version is guaranteed to exist in the target index because it was discovered from that same index.

This was identified during GPU CI on PR #507. PR #208 was not affected because it merged before `torch 2.12.0` was published to PyPI, at that point `2.11.0` was the latest on both PyPI and cu128, so the existing logic worked. Any PR running CI now will hit this failure until the cu128 index catches up.

## Issue Link

closes #640 

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch
- [x] I have performed a self-review of my code
- [x] I have placed in-line comments to clarify the intent of the hard-to-understand passages of my code
- [x] I have given the PR a name that clearly describes the change, written in imperative form.

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change