### PR TITLE
Fix hierarchical g2m/m2g edge_index zero-indexing (use total mesh-node count)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix hierarchical g2m/m2g `edge_index` zero-indexing: `zero_index_g2m`
+  and `zero_index_m2g` now offset grid nodes by the total mesh-node count
+  across all levels instead of the bottom-level count, matching how
+  `create_graph` numbers nodes. This resolves an `IndexError` in the GNN
+  layers during the HiLAM forward pass on hierarchical graphs; flat
+  graphs are unaffected. Adds a regression test that loads hierarchical
+  graphs and checks the zero-indexed g2m/m2g bounds.
+  ([#642](https://github.com/mllam/neural-lam/issues/642))
+  @Sir-Sloth-The-Lazy
+
 - Change metric heatmap (`plot_error_map`, now `plot_error_heatmap`) to use a
   shared cross-variable color scale instead of per-row normalization, add a
   colorbar, and scale figure size and font sizes with grid dimensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix hierarchical g2m/m2g `edge_index` zero-indexing: `zero_index_g2m`
-  and `zero_index_m2g` now offset grid nodes by the total mesh-node count
-  across all levels instead of the bottom-level count, matching how
-  `create_graph` numbers nodes. This resolves an `IndexError` in the GNN
-  layers during the HiLAM forward pass on hierarchical graphs; flat
-  graphs are unaffected. Adds a regression test that loads hierarchical
-  graphs and checks the zero-indexed g2m/m2g bounds.
-  ([#642](https://github.com/mllam/neural-lam/issues/642))
-  @Sir-Sloth-The-Lazy
+- Fix `IndexError` in HiLAM forward pass by offsetting grid nodes in `zero_index_g2m`/`zero_index_m2g` by the total mesh-node count across all levels ([#642](https://github.com/mllam/neural-lam/issues/642)) @Sir-Sloth-The-Lazy
 
 - Change metric heatmap (`plot_error_map`, now `plot_error_heatmap`) to use a
   shared cross-variable color scale instead of per-row normalization, add a

--- a/neural_lam/utils.py
+++ b/neural_lam/utils.py
@@ -98,8 +98,10 @@ def zero_index_m2g(
     sign = 1 if restore else -1
 
     if mesh_first:
-        # Mesh has the first indices, adjust grid indices (row 1)
-        num_mesh_nodes = mesh_static_features[0].shape[0]
+        # Mesh has the first indices, adjust grid indices (row 1).
+        # Use the total number of mesh nodes across all levels because
+        # create_graph offsets grid nodes by the full mesh node count.
+        num_mesh_nodes = sum(sf.shape[0] for sf in mesh_static_features)
         return torch.stack(
             (
                 m2g_edge_index[0],
@@ -150,8 +152,10 @@ def zero_index_g2m(
     sign = 1 if restore else -1
 
     if mesh_first:
-        # Mesh has the first indices, adjust grid indices (row 0)
-        num_mesh_nodes = mesh_static_features[0].shape[0]
+        # Mesh has the first indices, adjust grid indices (row 0).
+        # Use the total number of mesh nodes across all levels because
+        # create_graph offsets grid nodes by the full mesh node count.
+        num_mesh_nodes = sum(sf.shape[0] for sf in mesh_static_features)
         return torch.stack(
             (
                 g2m_edge_index[0] + sign * num_mesh_nodes,

--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -10,6 +10,7 @@ import torch
 from neural_lam.create_graph import create_graph_from_datastore
 from neural_lam.datastore import DATASTORES
 from neural_lam.datastore.base import BaseRegularGridDatastore
+from neural_lam.utils import load_graph
 from tests.conftest import init_datastore_example
 
 
@@ -117,3 +118,79 @@ def test_graph_creation(datastore_name, graph_name):
                         assert r.shape[0] == 2  # adjacency matrix uses two rows
                     elif file_id.endswith("_features"):
                         assert r.shape[1] == d_features
+
+
+@pytest.mark.parametrize("graph_name", ["1level", "multiscale", "hierarchical"])
+@pytest.mark.parametrize("datastore_name", DATASTORES.keys())
+def test_loaded_g2m_m2g_indices_in_bounds(datastore_name, graph_name):
+    """Regression test for the hierarchical g2m/m2g zero-indexing bug.
+
+    ``create_graph`` numbers grid nodes after the *total* mesh-node count
+    across all hierarchy levels, so ``zero_index_g2m``/``zero_index_m2g``
+    must subtract that same total. Previously they used only the
+    bottom-level mesh count, which left grid indices offset out of bounds
+    for hierarchical graphs and raised an ``IndexError`` in the GNN layers.
+
+    Assert that, after ``load_graph`` zero-indexes the edges, the grid-side
+    indices are zero-based and local (``< num_grid_points``) and the
+    mesh-side indices are local (``< num_mesh_nodes``). With the
+    bottom-level-only offset the grid-side indices stay shifted past
+    ``num_grid_points`` for hierarchical graphs.
+    """
+    datastore = init_datastore_example(datastore_name)
+
+    if not isinstance(datastore, BaseRegularGridDatastore):
+        pytest.skip(
+            f"Skipping test for {datastore_name} as it is not a regular "
+            "grid datastore."
+        )
+
+    if graph_name == "hierarchical":
+        hierarchical = True
+        n_max_levels = 3
+    elif graph_name == "multiscale":
+        hierarchical = False
+        n_max_levels = 3
+    else:
+        hierarchical = False
+        n_max_levels = 1
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        graph_dir_path = Path(tmpdir) / "graph" / graph_name
+        create_graph_from_datastore(
+            datastore=datastore,
+            output_root_path=str(graph_dir_path),
+            hierarchical=hierarchical,
+            n_max_levels=n_max_levels,
+        )
+
+        is_hierarchical, graph = load_graph(graph_dir_path=graph_dir_path)
+
+        mesh_static_features = graph["mesh_static_features"]
+        if is_hierarchical:
+            num_mesh_nodes = sum(sf.shape[0] for sf in mesh_static_features)
+        else:
+            num_mesh_nodes = mesh_static_features.shape[0]
+        num_grid_nodes = datastore.num_grid_points
+
+        # create_graph builds g2m edges grid -> mesh and m2g edges
+        # mesh -> grid, so after zero-indexing:
+        #   g2m_edge_index = [grid (sender), mesh (receiver)]
+        #   m2g_edge_index = [mesh (sender), grid (receiver)]
+        index_roles = {
+            "g2m_edge_index": ("grid", "mesh"),
+            "m2g_edge_index": ("mesh", "grid"),
+        }
+        bound = {"grid": num_grid_nodes, "mesh": num_mesh_nodes}
+
+        for name, roles in index_roles.items():
+            edge_index = graph[name]
+            assert edge_index.min() >= 0, f"Negative index in {name}"
+            for row, role in enumerate(roles):
+                row_max = int(edge_index[row].max())
+                assert row_max < bound[role], (
+                    f"{name} {role}-side index {row_max} is out of bounds: "
+                    f"expected a zero-based local index < {bound[role]} "
+                    f"({role} node count). num_mesh_nodes={num_mesh_nodes}, "
+                    f"num_grid_nodes={num_grid_nodes}."
+                )


### PR DESCRIPTION
## Describe your changes

`create_graph` numbers grid nodes after the **total** mesh-node count across all hierarchy levels: for the g2m/m2g graphs it adds nodes from every mesh level (`networkx.union_all(...)`) before the grid nodes and then sorts, so `from_networkx` assigns grid nodes indices starting at the full mesh-node count.

`zero_index_g2m` / `zero_index_m2g` in `neural_lam/utils.py`, however, subtracted only the **bottom-level** mesh count (`mesh_static_features[0].shape[0]`). For hierarchical graphs (`n_levels > 1`) this left grid indices offset out of bounds, raising an `IndexError` in `InteractionNet` during the HiLAM forward pass. Flat (single-level) graphs were unaffected because `len(mesh_static_features) == 1`.

This PR changes both helpers to offset by `sum(sf.shape[0] for sf in mesh_static_features)` (the total across all levels). For flat graphs this reduces exactly to the previous value, so non-hierarchical behaviour is unchanged.

It also adds a regression test (`test_loaded_g2m_m2g_indices_in_bounds`) that builds `1level` / `multiscale` / `hierarchical` graphs, loads them via `load_graph`, and asserts the zero-indexed g2m/m2g grid- and mesh-side indices are local and in bounds. The test fails on the previous behaviour for hierarchical graphs and passes with this fix. The existing suite never exercised this path: `test_graph_creation.py` only checked saved-file shapes and never called `load_graph` or ran a hierarchical forward pass.

Observed error before the fix (3-level hierarchical graph, HiLAM forward):

```
IndexError: Encountered an index error. Please ensure that all indices in
'edge_index' point to valid indices in the interval [0, 8408]
(got interval [819, 8498])
```

The offset of 819 = 729 + 81 + 9 (total mesh nodes across all three levels), confirming the wrong mesh count was used.

## Issue Link

closes #642

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section reflecting type of change (`fixed`).