### PR TITLE
test: register `slow` pytest marker and apply to training tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Maintenance
 
+- Register a `slow` pytest marker and apply it to `test_training` and `test_training_output_std` so contributors can skip long-running training tests during local iteration via `pytest -m "not slow"`. [\#651](https://github.com/mllam/neural-lam/pull/651) @sadamov
+
 - Add a short README pointer to [\#163](https://github.com/mllam/neural-lam/issues/163) for DGX Spark / PyTorch container compatibility notes, so users hitting `torch_scatter` errors know where to find the known-working / known-failing combos [\#266](https://github.com/mllam/neural-lam/pull/266) @Jayant-kernel
 
 - Group the existing Neural-LAM citation papers in the README under a `### Core Neural-LAM Publications` subheading for clearer structure [\#633](https://github.com/mllam/neural-lam/pull/633) @HetaviM29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,11 @@ allow-any-import-level = "neural_lam"
 [tool.pylint.SIMILARITIES]
 min-similarity-lines = 10
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselected by default, run with -m slow)",
+]
+
 [build-system]
 requires = ["hatchling>=1.27.0", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -141,6 +141,7 @@ def run_simple_training(
     trainer.fit(model=model, datamodule=data_module)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("datastore_name", DATASTORES.keys())
 def test_training(datastore_name):
     datastore = init_datastore_example(datastore_name)
@@ -154,6 +155,7 @@ def test_training(datastore_name):
     run_simple_training(datastore, set_output_std=False)
 
 
+@pytest.mark.slow
 def test_training_output_std():
     datastore = init_datastore_example("mdp")  # Test only with mdp datastore
     run_simple_training(datastore, set_output_std=True)


### PR DESCRIPTION
## Describe your changes

Register a `slow` pytest marker in `pyproject.toml` and apply `@pytest.mark.slow` to `test_training` (parametrised over all datastores) and `test_training_output_std` because they run a real `trainer.fit` loop and take minutes per parametrisation.

This relies on pytest's built-in marker filtering rather than introducing a custom flag:

- `pytest` (no flags) runs the full suite, slow tests included. CI uses this and continues to exercise everything.
- `pytest -m "not slow"` skips slow tests, for fast local iteration during contributor development.
- `pytest -m slow` runs only slow tests, e.g. when debugging a training regression.

Motivation: I needed this in #635 for the ERA5 boundary integration test, then realised the mechanism is independently useful for the existing trainer.fit-based tests too. Landing the marker separately so #635 doesn't have to ship two things at once, and so #231's `test_state_only_datastore_training_setup_runs` (and any future trainer.fit-based regression) can opt in via the same marker.

Coordination with #615 (@jishanahmed-shaikh): orthogonal. The `slow` marker is about execution time, the unit/integration split is about scope. They coexist: an integration test can be fast (DummyDatastore) and a unit test can be slow (large numerical fixture).

Earlier iteration of this PR introduced a custom `--run-slow` CLI flag with skip-by-default behaviour. @observingClouds suggested the inverse (run-by-default with `--skip-slow`), and the cleanest resolution was to drop the custom flag entirely and rely on pytest's native `-m` selection. Pytest already supports exactly this pattern with zero custom code.

No new dependencies. No CI changes.

Verified locally:
- `pytest tests/test_training.py --collect-only -q` -> all 6 tests collected
- `pytest tests/test_training.py -m "not slow" --collect-only -q` -> 2 collected, 4 deselected

## Issue Link

Refs #635, refs #599

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [x] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [x] PR is up to date with the base branch
- [x] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.