### PR TITLE
Rename d_mesh_static to num_mesh_static_vars

### DIFF
--- a/neural_lam/create_graph.py
+++ b/neural_lam/create_graph.py
@@ -282,7 +282,7 @@ def create_graph(
     - m2m_edge_index.pt  list of [2, N_m2m_edges_level], length==n_levels
     - m2m_features.pt    list of [N_m2m_edges_level, d_features],
                          length==n_levels
-    - mesh_features.pt   list of [N_mesh_nodes_level, d_mesh_static],
+    - mesh_features.pt   list of [N_mesh_nodes_level, num_mesh_static_vars],
                          length==n_levels
 
     where
@@ -296,9 +296,9 @@ def create_graph(
       N_m2m_edges_level:
             number of edges in the graph from mesh-to-mesh at a given level
             (list index corresponds to the level)
-      d_mesh_static:
+      num_mesh_static_vars:
             number of static features per mesh node (currently
-            d_mesh_static==2, for x and y)
+            num_mesh_static_vars==2, for x and y)
       N_mesh_nodes_level:
             number of nodes in the mesh at a given level
 

--- a/neural_lam/utils.py
+++ b/neural_lam/utils.py
@@ -325,7 +325,7 @@ def load_graph(
     # Load static node features
     mesh_static_features = loads_file(
         "mesh_features.pt"
-    )  # List of (N_mesh[l], d_mesh_static)
+    )  # List of (N_mesh[l], num_mesh_static_vars)
 
     # Load edges (edge_index)
     m2m_edge_index = BufferList(

--- a/tests/test_graph_creation.py
+++ b/tests/test_graph_creation.py
@@ -64,7 +64,7 @@ def test_graph_creation(datastore_name, graph_name):
     # TODO: check that the number of edges is consistent over the files, for
     # now we just check the number of features
     d_features = 3
-    d_mesh_static = 2
+    num_mesh_static_vars = 2
 
     with tempfile.TemporaryDirectory() as tmpdir:
         graph_dir_path = Path(tmpdir) / "graph" / graph_name
@@ -113,7 +113,7 @@ def test_graph_creation(datastore_name, graph_name):
                     assert isinstance(r, torch.Tensor)
 
                     if file_id == "mesh_features":
-                        assert r.shape[1] == d_mesh_static
+                        assert r.shape[1] == num_mesh_static_vars
                     elif file_id.endswith("_index"):
                         assert r.shape[0] == 2  # adjacency matrix uses two rows
                     elif file_id.endswith("_features"):


### PR DESCRIPTION
Renamed `d_mesh_static` to `num_mesh_static_vars` throughout the repository to match the canonical naming convention.

- Updated source code
- Updated comments and docstrings