### PR TITLE
Fix logger config for datastores without _config

### DIFF
--- a/neural_lam/utils/logging.py
+++ b/neural_lam/utils/logging.py
@@ -117,7 +117,7 @@ def setup_training_logger(
         return pl.loggers.WandbLogger(
             project=args.logger_project,
             name=None if args.wandb_id else run_name,
-            config=dict(training=vars(args), datastore=datastore._config),
+            config=dict(training=vars(args), datastore=getattr(datastore, "_config", None)),
             resume=wandb_resume,
             id=args.wandb_id,
             save_dir=run_dir,
@@ -140,7 +140,7 @@ def setup_training_logger(
             save_dir=run_dir,
         )
         training_logger.log_hyperparams(
-            dict(training=vars(args), datastore=datastore._config)
+            dict(training=vars(args), datastore=getattr(datastore, "_config", None))
         )
         return training_logger
     else:


### PR DESCRIPTION
## Summary

This PR updates `setup_training_logger` to avoid assuming that every datastore exposes a private `_config` attribute.

It replaces direct access to:

```python
datastore._config
```

with:

```python
getattr(datastore, "_config", None)
```

This prevents an `AttributeError` for datastores that do not implement `_config` while preserving the existing behavior for datastores that do.

## Issue

Closes #709