### PR TITLE
Load flat graphs into pyg.HeteroData and wire into BaseGraphModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased](https://github.com/mllam/neural-lam/compare/v0.6.0...HEAD)
 
 ### Added
+- Add `neural_lam.utils.heterodata` for representing the loaded graph as a
+  `pyg.HeteroData` object, with grid nodes as the `grid` node type, mesh nodes
+  as the `mesh` node type and `g2m`/`m2m`/`m2g` as typed edges.
+  `BaseGraphModel` reads its graph tensors out of that object when constructed
+  with `use_heterodata=True` (default `False`), which leaves the model's
+  behaviour, and therefore training, unchanged. Flat (non-hierarchical) graphs
+  only. [\#711](https://github.com/mllam/neural-lam/pull/711) @prajwal-tech07
+
 - Add `--num_sanity_val_steps` CLI argument to control sanity validation steps before training (#694)
 
 - Add `--train_steps_to_log` CLI option to log training loss for individual unroll steps, and deduplicate common prediction and loss computation steps across loops [\#674](https://github.com/mllam/neural-lam/issues/674) @GiGiKoneti

--- a/neural_lam/models/step_predictors/graph/base.py
+++ b/neural_lam/models/step_predictors/graph/base.py
@@ -116,11 +116,12 @@ class BaseGraphModel(StepPredictor):
             mesh_node_features_scaling=grid_xy_max_span,
         )
 
-        # Optionally represent the graph as a pyg.HeteroData object and take
-        # the model's graph tensors from it, so that everywhere the graph is
-        # used the data now originates from the HeteroData datastructure
-        # (issue #385). The extracted tensors are identical to the dict ones,
-        # so the model builds and trains identically either way.
+        # Optionally represent the graph as a pyg.HeteroData object (issue
+        # #385). The loaded tensors are placed on the typed node/edge stores
+        # of that object, and every graph tensor the model uses below is then
+        # read back out of it, so the HeteroData is the source of the graph
+        # data. The tensors themselves are unchanged, so the model builds and
+        # trains identically either way.
         self.use_heterodata = use_heterodata
         if use_heterodata:
             if self.hierarchical:
@@ -132,7 +133,7 @@ class BaseGraphModel(StepPredictor):
                 graph_ldict,
                 num_grid_nodes=self.num_grid_nodes,
             )
-            graph_ldict = utils.heterodata_to_graph_dict(self.graph)
+            graph_ldict = utils.graph_tensors_from_heterodata(self.graph)
 
         for name, attr_value in graph_ldict.items():
             # Make BufferLists module members and register tensors as buffers

--- a/neural_lam/models/step_predictors/graph/base.py
+++ b/neural_lam/models/step_predictors/graph/base.py
@@ -33,6 +33,7 @@ class BaseGraphModel(StepPredictor):
         output_clamping_upper: dict[str, float] | None = None,
         g2m_gnn_type: str = "InteractionNet",
         m2g_gnn_type: str = "InteractionNet",
+        use_heterodata: bool = False,
     ) -> None:
         """
         Initialize the BaseGraphModel.
@@ -62,6 +63,10 @@ class BaseGraphModel(StepPredictor):
             Lower clamping limits for state variables.
         output_clamping_upper : dict, optional
             Upper clamping limits for state variables.
+        use_heterodata : bool, default False
+            If True, represent the loaded graph as a ``pyg.HeteroData``
+            object and take the model's graph tensors from it. Only supported
+            for flat (non-hierarchical) graphs.
         """
         super().__init__(
             datastore=datastore,
@@ -110,6 +115,24 @@ class BaseGraphModel(StepPredictor):
             graph_dir_path=graph_dir_path,
             mesh_node_features_scaling=grid_xy_max_span,
         )
+
+        # Optionally represent the graph as a pyg.HeteroData object and take
+        # the model's graph tensors from it, so that everywhere the graph is
+        # used the data now originates from the HeteroData datastructure
+        # (issue #385). The extracted tensors are identical to the dict ones,
+        # so the model builds and trains identically either way.
+        self.use_heterodata = use_heterodata
+        if use_heterodata:
+            if self.hierarchical:
+                raise NotImplementedError(
+                    "use_heterodata is currently only supported for flat "
+                    "(non-hierarchical) graphs."
+                )
+            self.graph = utils.graph_dict_to_heterodata(
+                graph_ldict,
+                num_grid_nodes=self.num_grid_nodes,
+            )
+            graph_ldict = utils.heterodata_to_graph_dict(self.graph)
 
         for name, attr_value in graph_ldict.items():
             # Make BufferLists module members and register tensors as buffers

--- a/neural_lam/models/step_predictors/graph/base.py
+++ b/neural_lam/models/step_predictors/graph/base.py
@@ -4,6 +4,7 @@
 
 # Third-party
 import torch
+from torch_geometric.data import HeteroData
 
 # Local
 from .... import utils
@@ -176,6 +177,36 @@ class BaseGraphModel(StepPredictor):
 
         # Compute indices and define clamping functions
         self.prepare_clamping_params(datastore)
+
+    @property
+    def graph(self) -> HeteroData:
+        """The model's graph as a ``pyg.HeteroData`` object.
+
+        Built on access from the graph tensors currently registered on the
+        model, so it always agrees with their device and dtype. It is not
+        stored on the model, because a ``HeteroData`` attribute would not be
+        moved by ``.to(...)`` and would go stale.
+
+        Returns
+        -------
+        torch_geometric.data.HeteroData
+            Typed graph referencing the model's current graph tensors.
+
+        Raises
+        ------
+        AttributeError
+            If the model was not constructed with ``use_heterodata=True``.
+        """
+        if not self.use_heterodata:
+            raise AttributeError(
+                "graph is only available on models constructed with "
+                "use_heterodata=True"
+            )
+        return utils.heterodata_from_module(
+            self,
+            num_grid_nodes=self.num_grid_nodes,
+            hierarchical=self.hierarchical,
+        )
 
     def get_num_mesh(self) -> tuple[int, int]:
         """

--- a/neural_lam/models/step_predictors/graph/graph_lam.py
+++ b/neural_lam/models/step_predictors/graph/graph_lam.py
@@ -36,6 +36,7 @@ class GraphLAM(BaseGraphModel):
         output_clamping_upper: dict[str, float] | None = None,
         g2m_gnn_type: str = "InteractionNet",
         m2g_gnn_type: str = "InteractionNet",
+        use_heterodata: bool = False,
     ) -> None:
         """
         Initialize the GraphLAM model.
@@ -64,6 +65,10 @@ class GraphLAM(BaseGraphModel):
             Lower clamping limits for state variables.
         output_clamping_upper : dict, optional
             Upper clamping limits for state variables.
+        use_heterodata : bool, default False
+            If True, represent the loaded graph as a ``pyg.HeteroData``
+            object and take the model's graph tensors from it. Only supported
+            for flat (non-hierarchical) graphs.
         """
         super().__init__(
             datastore=datastore,
@@ -79,6 +84,7 @@ class GraphLAM(BaseGraphModel):
             output_clamping_upper=output_clamping_upper,
             g2m_gnn_type=g2m_gnn_type,
             m2g_gnn_type=m2g_gnn_type,
+            use_heterodata=use_heterodata,
         )
 
         assert (

--- a/neural_lam/models/step_predictors/graph/hi_lam.py
+++ b/neural_lam/models/step_predictors/graph/hi_lam.py
@@ -37,6 +37,7 @@ class HiLAM(BaseHiGraphModel):
         m2g_gnn_type: str = "InteractionNet",
         mesh_up_gnn_type: str = "InteractionNet",
         mesh_down_gnn_type: str = "InteractionNet",
+        use_heterodata: bool = False,
     ):
         """
         Initialize the HiLAM model.
@@ -82,6 +83,7 @@ class HiLAM(BaseHiGraphModel):
             m2g_gnn_type=m2g_gnn_type,
             mesh_up_gnn_type=mesh_up_gnn_type,
             mesh_down_gnn_type=mesh_down_gnn_type,
+            use_heterodata=use_heterodata,
         )
 
         # Make down GNNs, both for down edges and same level

--- a/neural_lam/models/step_predictors/graph/hi_lam_parallel.py
+++ b/neural_lam/models/step_predictors/graph/hi_lam_parallel.py
@@ -40,6 +40,7 @@ class HiLAMParallel(BaseHiGraphModel):
         m2g_gnn_type: str = "InteractionNet",
         mesh_up_gnn_type: str = "InteractionNet",
         mesh_down_gnn_type: str = "InteractionNet",
+        use_heterodata: bool = False,
     ):
         """
         Initialize the HiLAMParallel model.
@@ -85,6 +86,7 @@ class HiLAMParallel(BaseHiGraphModel):
             m2g_gnn_type=m2g_gnn_type,
             mesh_up_gnn_type=mesh_up_gnn_type,
             mesh_down_gnn_type=mesh_down_gnn_type,
+            use_heterodata=use_heterodata,
         )
 
         # Processor GNNs

--- a/neural_lam/models/step_predictors/graph/hierarchical.py
+++ b/neural_lam/models/step_predictors/graph/hierarchical.py
@@ -34,6 +34,7 @@ class BaseHiGraphModel(BaseGraphModel):
         m2g_gnn_type: str = "InteractionNet",
         mesh_up_gnn_type: str = "InteractionNet",
         mesh_down_gnn_type: str = "InteractionNet",
+        use_heterodata: bool = False,
     ):
         """Extend :class:`BaseGraphModel` with hierarchical mesh structures."""
         super().__init__(
@@ -50,6 +51,7 @@ class BaseHiGraphModel(BaseGraphModel):
             output_clamping_upper=output_clamping_upper,
             g2m_gnn_type=g2m_gnn_type,
             m2g_gnn_type=m2g_gnn_type,
+            use_heterodata=use_heterodata,
         )
         self.mesh_up_gnn_type = mesh_up_gnn_type
         self.mesh_down_gnn_type = mesh_down_gnn_type

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -62,6 +62,8 @@ def load_forecaster_module_from_checkpoint(ckpt_path, config, datastore):
         output_std=args.output_std,
         output_clamping_lower=config.training.output_clamping.lower,
         output_clamping_upper=config.training.output_clamping.upper,
+        # Checkpoints written before this flag existed have no such arg
+        use_heterodata=getattr(args, "use_heterodata", False),
     )
     forecaster = ARForecaster(predictor, datastore)
     return ForecasterModule.load_from_checkpoint(
@@ -175,6 +177,12 @@ def main(input_args=None):
         action="store_true",
         help="If models should additionally output std.-dev. per "
         "output dimensions",
+    )
+    arch_group.add_argument(
+        "--use_heterodata",
+        action="store_true",
+        help="Represent the loaded graph as a pyg.HeteroData object and take "
+        "the model's graph tensors from it (flat graphs only for now)",
     )
     arch_group.add_argument(
         "--g2m_gnn_type",
@@ -478,6 +486,7 @@ def main(input_args=None):
         m2g_gnn_type=args.m2g_gnn_type,
         mesh_up_gnn_type=args.mesh_up_gnn_type,
         mesh_down_gnn_type=args.mesh_down_gnn_type,
+        use_heterodata=args.use_heterodata,
     )
     forecaster = ARForecaster(predictor, datastore)
 

--- a/neural_lam/utils/__init__.py
+++ b/neural_lam/utils/__init__.py
@@ -8,6 +8,10 @@ from .graph import (
     zero_index_g2m,
     zero_index_m2g,
 )
+from .heterodata import (
+    graph_dict_to_heterodata,
+    heterodata_to_graph_dict,
+)
 from .logging import (
     init_training_logger_metrics,
     log_on_rank_zero,
@@ -22,7 +26,9 @@ __all__ = [
     "BufferList",
     "fractional_plot_bundle",
     "get_integer_time",
+    "graph_dict_to_heterodata",
     "has_working_latex",
+    "heterodata_to_graph_dict",
     "init_training_logger_metrics",
     "inverse_sigmoid",
     "inverse_softplus",

--- a/neural_lam/utils/__init__.py
+++ b/neural_lam/utils/__init__.py
@@ -10,7 +10,7 @@ from .graph import (
 )
 from .heterodata import (
     graph_dict_to_heterodata,
-    heterodata_to_graph_dict,
+    graph_tensors_from_heterodata,
 )
 from .logging import (
     init_training_logger_metrics,
@@ -27,8 +27,8 @@ __all__ = [
     "fractional_plot_bundle",
     "get_integer_time",
     "graph_dict_to_heterodata",
+    "graph_tensors_from_heterodata",
     "has_working_latex",
-    "heterodata_to_graph_dict",
     "init_training_logger_metrics",
     "inverse_sigmoid",
     "inverse_softplus",

--- a/neural_lam/utils/__init__.py
+++ b/neural_lam/utils/__init__.py
@@ -13,6 +13,7 @@ from .graph import (
 from .heterodata import (
     graph_dict_to_heterodata,
     graph_tensors_from_heterodata,
+    heterodata_from_module,
 )
 from .logging import (
     init_training_logger_metrics,
@@ -32,6 +33,7 @@ __all__ = [
     "graph_dict_to_heterodata",
     "graph_tensors_from_heterodata",
     "has_working_latex",
+    "heterodata_from_module",
     "init_training_logger_metrics",
     "inverse_sigmoid",
     "inverse_softplus",

--- a/neural_lam/utils/graph.py
+++ b/neural_lam/utils/graph.py
@@ -438,12 +438,13 @@ def load_and_register_graph(
     buffer and each non-tensor (e.g. ``BufferList``) as a plain attribute on
     ``module``.
 
-    With ``use_heterodata`` the loaded tensors are first placed on the typed
-    node/edge stores of a ``pyg.HeteroData`` object (issue #385), which is
-    stored as ``module.graph``, and the tensors registered on ``module`` are
-    then read back out of that object, making it the source of the module's
-    graph data. The tensors themselves are unchanged, so the module behaves,
-    and therefore trains, identically either way.
+    With ``use_heterodata`` the loaded tensors are routed through a
+    ``pyg.HeteroData`` object (issue #385): they are placed on its typed
+    node/edge stores and the tensors registered on ``module`` are then read
+    back out of it. The object is not stored on ``module``; see
+    :func:`neural_lam.utils.heterodata_from_module` for building a view of
+    the registered tensors on demand. The tensors themselves are unchanged,
+    so the module behaves, and therefore trains, identically either way.
 
     Parameters
     ----------
@@ -457,9 +458,9 @@ def load_and_register_graph(
         Scalar used to normalize mesh node coordinate features for graphs in
         the current on-disk format; forwarded to :func:`load_graph`.
     use_heterodata : bool, default False
-        Whether to represent the graph as a ``pyg.HeteroData`` object on
-        ``module.graph`` and take the registered tensors from it. Only
-        supported for flat (non-hierarchical) graphs.
+        Whether to route the graph tensors through a ``pyg.HeteroData``
+        object and take the registered tensors from it. Only supported for
+        flat (non-hierarchical) graphs.
 
     Returns
     -------
@@ -483,11 +484,11 @@ def load_and_register_graph(
                 "use_heterodata is currently only supported for flat "
                 "(non-hierarchical) graphs."
             )
-        module.graph = graph_dict_to_heterodata(
+        graph = graph_dict_to_heterodata(
             graph_ldict,
             num_grid_nodes=datastore.num_grid_points,
         )
-        graph_ldict = graph_tensors_from_heterodata(module.graph)
+        graph_ldict = graph_tensors_from_heterodata(graph)
 
     for name, attr_value in graph_ldict.items():
         # Make BufferLists module members and register tensors as buffers

--- a/neural_lam/utils/heterodata.py
+++ b/neural_lam/utils/heterodata.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 # Third-party
+import torch
 from torch_geometric.data import HeteroData
 
 # Local
@@ -47,6 +48,22 @@ _FLAT_EDGE_SPEC = (
     (G2M_EDGE_TYPE, "g2m_edge_index", "g2m_features"),
     (M2M_EDGE_TYPE, "m2m_edge_index", "m2m_features"),
     (M2G_EDGE_TYPE, "m2g_edge_index", "m2g_features"),
+)
+
+# Names the graph tensors are registered under on a module, i.e. the keys of
+# the tensor-dict returned by :func:`neural_lam.utils.load_graph`.
+GRAPH_TENSOR_NAMES = (
+    "g2m_edge_index",
+    "m2g_edge_index",
+    "m2m_edge_index",
+    "mesh_up_edge_index",
+    "mesh_down_edge_index",
+    "g2m_features",
+    "m2g_features",
+    "m2m_features",
+    "mesh_up_features",
+    "mesh_down_features",
+    "mesh_static_features",
 )
 
 
@@ -158,3 +175,42 @@ def graph_tensors_from_heterodata(
         graph_dict[edge_feature_key] = graph[edge_type].edge_attr
 
     return graph_dict
+
+
+def heterodata_from_module(
+    module: torch.nn.Module,
+    num_grid_nodes: int,
+    hierarchical: bool = False,
+) -> HeteroData:
+    """Build a ``HeteroData`` view of the graph tensors held by ``module``.
+
+    The object is built on demand from the graph tensors currently registered
+    on ``module``, rather than being stored on it. A stored ``HeteroData``
+    would not be moved by :meth:`torch.nn.Module._apply`, since it is neither
+    a tensor, parameter nor module, so it would keep referring to the
+    pre-move tensors after e.g. ``.to(device)`` and silently disagree with the
+    module's buffers. Building it on access keeps it consistent with whatever
+    device and dtype the module currently holds, and adds no copies: the
+    returned object references the module's tensors.
+
+    Parameters
+    ----------
+    module : torch.nn.Module
+        Module the graph tensors were registered on, e.g. by
+        :func:`neural_lam.utils.load_and_register_graph`.
+    num_grid_nodes : int
+        Number of grid nodes.
+    hierarchical : bool, default False
+        Whether the graph is hierarchical.
+
+    Returns
+    -------
+    torch_geometric.data.HeteroData
+        Typed graph referencing ``module``'s current graph tensors.
+    """
+    graph_dict = {name: getattr(module, name) for name in GRAPH_TENSOR_NAMES}
+    return graph_dict_to_heterodata(
+        graph_dict,
+        num_grid_nodes=num_grid_nodes,
+        hierarchical=hierarchical,
+    )

--- a/neural_lam/utils/heterodata.py
+++ b/neural_lam/utils/heterodata.py
@@ -4,16 +4,19 @@ The tensor-dict is the representation returned by
 :func:`neural_lam.utils.load_graph` (a dictionary of edge-index and
 node/edge-feature tensors, see that function's docstring for the keys).
 
-The ``HeteroData`` representation follows the node/edge-type convention used
-in the reference implementations linked from issue #385
-(``leifdenby/weatherduck`` and ``matschreiner/equicast``): the grid nodes,
-which carry the physical data, are the ``"data"`` node type and the mesh
-nodes, the latent representation the model processes on, are the ``"hidden"``
-node type. The three graph components map onto typed edges:
+The ``HeteroData`` representation uses the ``"grid"`` and ``"mesh"`` node
+types, matching the terminology used throughout the rest of ``neural-lam``
+(``grid_static_features``, ``mesh_static_features``, ``g2m``/``m2m``/``m2g``).
+The three graph components map onto typed edges:
 
-- ``g2m`` (grid-to-mesh)  -> ``("data", "to", "hidden")``
-- ``m2m`` (mesh-to-mesh)  -> ``("hidden", "to", "hidden")``
-- ``m2g`` (mesh-to-grid)  -> ``("hidden", "to", "data")``
+- ``g2m`` (grid-to-mesh)  -> ``("grid", "to", "mesh")``
+- ``m2m`` (mesh-to-mesh)  -> ``("mesh", "to", "mesh")``
+- ``m2g`` (mesh-to-grid)  -> ``("mesh", "to", "grid")``
+
+The node/edge-type names are defined as module-level constants so the naming
+convention can be changed in one place (the reference implementations in
+issue #385, ``leifdenby/weatherduck`` and ``matschreiner/equicast``, use
+``"data"``/``"hidden"`` instead).
 
 Only flat (single mesh level) graphs are supported for now; hierarchical
 graphs raise :class:`NotImplementedError` and are handled in a follow-up.
@@ -32,8 +35,8 @@ from .buffer_list import BufferList
 
 # Node/edge-type names, kept in one place so the naming convention (see the
 # issue #385 discussion) can be changed without touching call sites.
-GRID_NODE_TYPE = "data"
-MESH_NODE_TYPE = "hidden"
+GRID_NODE_TYPE = "grid"
+MESH_NODE_TYPE = "mesh"
 G2M_EDGE_TYPE = (GRID_NODE_TYPE, "to", MESH_NODE_TYPE)
 M2M_EDGE_TYPE = (MESH_NODE_TYPE, "to", MESH_NODE_TYPE)
 M2G_EDGE_TYPE = (MESH_NODE_TYPE, "to", GRID_NODE_TYPE)
@@ -61,9 +64,9 @@ def graph_dict_to_heterodata(
         a flat graph ``m2m_edge_index``, ``m2m_features`` and
         ``mesh_static_features`` are single tensors (not lists).
     num_grid_nodes : int
-        Number of grid ("data") nodes. Taken from the datastore rather than
-        inferred from the edge indices, because the graph spec allows grid
-        nodes that no edge connects to.
+        Number of grid nodes. Taken from the datastore rather than inferred
+        from the edge indices, because the graph spec allows grid nodes that
+        no edge connects to.
     hierarchical : bool, default False
         Whether the graph is hierarchical. Only ``False`` is supported for
         now.
@@ -71,9 +74,9 @@ def graph_dict_to_heterodata(
     Returns
     -------
     torch_geometric.data.HeteroData
-        Typed graph with ``"data"`` and ``"hidden"`` node types and the
+        Typed graph with ``"grid"`` and ``"mesh"`` node types and the
         ``g2m`` / ``m2m`` / ``m2g`` edge types. Mesh node features are stored
-        on ``graph["hidden"].x`` and edge features on ``edge_attr``. Tensors
+        on ``graph["mesh"].x`` and edge features on ``edge_attr``. Tensors
         are the same objects as in ``graph_dict`` (no copy).
 
     Raises
@@ -89,11 +92,11 @@ def graph_dict_to_heterodata(
 
     graph = HeteroData()
 
-    # Grid ("data") nodes have no stored static features here (grid features
-    # are dynamic and passed at forward time), so only the count is set.
+    # Grid nodes have no stored static features here (grid features are
+    # dynamic and passed at forward time), so only the count is set.
     graph[GRID_NODE_TYPE].num_nodes = int(num_grid_nodes)
 
-    # Mesh ("hidden") nodes carry their static coordinate features.
+    # Mesh nodes carry their static coordinate features.
     graph[MESH_NODE_TYPE].x = graph_dict["mesh_static_features"]
 
     for edge_type, edge_index_key, edge_feature_key in _FLAT_EDGE_SPEC:

--- a/neural_lam/utils/heterodata.py
+++ b/neural_lam/utils/heterodata.py
@@ -1,0 +1,156 @@
+"""Convert between neural-lam's graph tensor-dict and ``pyg.HeteroData``.
+
+The tensor-dict is the representation returned by
+:func:`neural_lam.utils.load_graph` (a dictionary of edge-index and
+node/edge-feature tensors, see that function's docstring for the keys).
+
+The ``HeteroData`` representation follows the node/edge-type convention used
+in the reference implementations linked from issue #385
+(``leifdenby/weatherduck`` and ``matschreiner/equicast``): the grid nodes,
+which carry the physical data, are the ``"data"`` node type and the mesh
+nodes, the latent representation the model processes on, are the ``"hidden"``
+node type. The three graph components map onto typed edges:
+
+- ``g2m`` (grid-to-mesh)  -> ``("data", "to", "hidden")``
+- ``m2m`` (mesh-to-mesh)  -> ``("hidden", "to", "hidden")``
+- ``m2g`` (mesh-to-grid)  -> ``("hidden", "to", "data")``
+
+Only flat (single mesh level) graphs are supported for now; hierarchical
+graphs raise :class:`NotImplementedError` and are handled in a follow-up.
+"""
+
+from __future__ import annotations
+
+# Standard library
+from typing import Any, Dict
+
+# Third-party
+from torch_geometric.data import HeteroData
+
+# Local
+from .buffer_list import BufferList
+
+# Node/edge-type names, kept in one place so the naming convention (see the
+# issue #385 discussion) can be changed without touching call sites.
+GRID_NODE_TYPE = "data"
+MESH_NODE_TYPE = "hidden"
+G2M_EDGE_TYPE = (GRID_NODE_TYPE, "to", MESH_NODE_TYPE)
+M2M_EDGE_TYPE = (MESH_NODE_TYPE, "to", MESH_NODE_TYPE)
+M2G_EDGE_TYPE = (MESH_NODE_TYPE, "to", GRID_NODE_TYPE)
+
+# (edge_type, edge_index dict key, edge_feature dict key) for the three
+# always-present components, iterated by both conversion directions.
+_FLAT_EDGE_SPEC = (
+    (G2M_EDGE_TYPE, "g2m_edge_index", "g2m_features"),
+    (M2M_EDGE_TYPE, "m2m_edge_index", "m2m_features"),
+    (M2G_EDGE_TYPE, "m2g_edge_index", "m2g_features"),
+)
+
+
+def graph_dict_to_heterodata(
+    graph_dict: Dict[str, Any],
+    num_grid_nodes: int,
+    hierarchical: bool = False,
+) -> HeteroData:
+    """Build a ``pyg.HeteroData`` from a neural-lam graph tensor-dict.
+
+    Parameters
+    ----------
+    graph_dict : dict
+        Graph tensors as returned by :func:`neural_lam.utils.load_graph`. For
+        a flat graph ``m2m_edge_index``, ``m2m_features`` and
+        ``mesh_static_features`` are single tensors (not lists).
+    num_grid_nodes : int
+        Number of grid ("data") nodes. Taken from the datastore rather than
+        inferred from the edge indices, because the graph spec allows grid
+        nodes that no edge connects to.
+    hierarchical : bool, default False
+        Whether the graph is hierarchical. Only ``False`` is supported for
+        now.
+
+    Returns
+    -------
+    torch_geometric.data.HeteroData
+        Typed graph with ``"data"`` and ``"hidden"`` node types and the
+        ``g2m`` / ``m2m`` / ``m2g`` edge types. Mesh node features are stored
+        on ``graph["hidden"].x`` and edge features on ``edge_attr``. Tensors
+        are the same objects as in ``graph_dict`` (no copy).
+
+    Raises
+    ------
+    NotImplementedError
+        If ``hierarchical`` is ``True``.
+    """
+    if hierarchical:
+        raise NotImplementedError(
+            "graph_dict_to_heterodata currently supports only flat "
+            "(single-level) graphs; hierarchical support is a follow-up."
+        )
+
+    graph = HeteroData()
+
+    # Grid ("data") nodes have no stored static features here (grid features
+    # are dynamic and passed at forward time), so only the count is set.
+    graph[GRID_NODE_TYPE].num_nodes = int(num_grid_nodes)
+
+    # Mesh ("hidden") nodes carry their static coordinate features.
+    graph[MESH_NODE_TYPE].x = graph_dict["mesh_static_features"]
+
+    for edge_type, edge_index_key, edge_feature_key in _FLAT_EDGE_SPEC:
+        graph[edge_type].edge_index = graph_dict[edge_index_key]
+        graph[edge_type].edge_attr = graph_dict[edge_feature_key]
+
+    return graph
+
+
+def heterodata_to_graph_dict(
+    graph: HeteroData,
+    hierarchical: bool = False,
+) -> Dict[str, Any]:
+    """Reconstruct a neural-lam graph tensor-dict from a ``HeteroData``.
+
+    Inverse of :func:`graph_dict_to_heterodata`. The returned dictionary has
+    the exact structure that :func:`neural_lam.utils.load_graph` produces for
+    a flat graph, so it can be consumed by the model unpacking logic
+    unchanged: single tensors for the mesh/edge entries and empty
+    :class:`~neural_lam.utils.buffer_list.BufferList` objects for the
+    (unused) hierarchical up/down entries.
+
+    Parameters
+    ----------
+    graph : torch_geometric.data.HeteroData
+        Graph as produced by :func:`graph_dict_to_heterodata`.
+    hierarchical : bool, default False
+        Whether the graph is hierarchical. Only ``False`` is supported for
+        now.
+
+    Returns
+    -------
+    dict
+        Graph tensor-dict with the same 11 keys as
+        :func:`neural_lam.utils.load_graph`.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``hierarchical`` is ``True``.
+    """
+    if hierarchical:
+        raise NotImplementedError(
+            "heterodata_to_graph_dict currently supports only flat "
+            "(single-level) graphs; hierarchical support is a follow-up."
+        )
+
+    graph_dict: Dict[str, Any] = {
+        "mesh_static_features": graph[MESH_NODE_TYPE].x,
+        # No inter-level edges for a flat graph.
+        "mesh_up_edge_index": BufferList([], persistent=False),
+        "mesh_down_edge_index": BufferList([], persistent=False),
+        "mesh_up_features": BufferList([], persistent=False),
+        "mesh_down_features": BufferList([], persistent=False),
+    }
+    for edge_type, edge_index_key, edge_feature_key in _FLAT_EDGE_SPEC:
+        graph_dict[edge_index_key] = graph[edge_type].edge_index
+        graph_dict[edge_feature_key] = graph[edge_type].edge_attr
+
+    return graph_dict

--- a/neural_lam/utils/heterodata.py
+++ b/neural_lam/utils/heterodata.py
@@ -106,18 +106,19 @@ def graph_dict_to_heterodata(
     return graph
 
 
-def heterodata_to_graph_dict(
+def graph_tensors_from_heterodata(
     graph: HeteroData,
     hierarchical: bool = False,
 ) -> Dict[str, Any]:
-    """Reconstruct a neural-lam graph tensor-dict from a ``HeteroData``.
+    """Read the model's graph tensors out of a ``HeteroData`` object.
 
-    Inverse of :func:`graph_dict_to_heterodata`. The returned dictionary has
-    the exact structure that :func:`neural_lam.utils.load_graph` produces for
-    a flat graph, so it can be consumed by the model unpacking logic
-    unchanged: single tensors for the mesh/edge entries and empty
-    :class:`~neural_lam.utils.buffer_list.BufferList` objects for the
-    (unused) hierarchical up/down entries.
+    This is how the model obtains its graph tensors when it represents the
+    graph as a ``HeteroData``: every tensor is looked up on the typed
+    node/edge stores of ``graph``. They are returned under the names the
+    model refers to them by (the same names
+    :func:`neural_lam.utils.load_graph` uses), so only the *source* of the
+    tensors changes, not the rest of the model's setup. It is also the exact
+    inverse of :func:`graph_dict_to_heterodata`.
 
     Parameters
     ----------
@@ -130,7 +131,7 @@ def heterodata_to_graph_dict(
     Returns
     -------
     dict
-        Graph tensor-dict with the same 11 keys as
+        The model's graph tensors, keyed by the names used in
         :func:`neural_lam.utils.load_graph`.
 
     Raises
@@ -140,7 +141,7 @@ def heterodata_to_graph_dict(
     """
     if hierarchical:
         raise NotImplementedError(
-            "heterodata_to_graph_dict currently supports only flat "
+            "graph_tensors_from_heterodata currently supports only flat "
             "(single-level) graphs; hierarchical support is a follow-up."
         )
 

--- a/tests/test_heterodata.py
+++ b/tests/test_heterodata.py
@@ -2,7 +2,7 @@
 
 Two layers of testing:
 
-- unit tests on ``graph_dict_to_heterodata`` / ``heterodata_to_graph_dict``
+- unit tests on ``graph_dict_to_heterodata`` / ``graph_tensors_from_heterodata``
   with small hand-built tensor-dicts (no datastore/model needed);
 - a model-level equivalence test showing that a ``GraphLAM`` built with
   ``use_heterodata=True`` is identical to one built the existing way, both in
@@ -22,7 +22,7 @@ from neural_lam.create_graph import create_graph_from_datastore
 from neural_lam.models import GraphLAM
 from neural_lam.utils import (
     graph_dict_to_heterodata,
-    heterodata_to_graph_dict,
+    graph_tensors_from_heterodata,
 )
 from neural_lam.utils.buffer_list import BufferList
 from neural_lam.utils.heterodata import (
@@ -132,7 +132,7 @@ def test_builder_roundtrip_is_exact():
     """dict -> HeteroData -> dict reproduces the original tensor-dict."""
     graph_dict = _flat_graph_dict()
     graph = graph_dict_to_heterodata(graph_dict, num_grid_nodes=6)
-    restored = heterodata_to_graph_dict(graph)
+    restored = graph_tensors_from_heterodata(graph)
 
     assert set(restored.keys()) == _GRAPH_DICT_KEYS
     for key in _GRAPH_DICT_KEYS:
@@ -170,7 +170,7 @@ def test_builder_rejects_hierarchical():
         )
     graph = graph_dict_to_heterodata(graph_dict, num_grid_nodes=6)
     with pytest.raises(NotImplementedError):
-        heterodata_to_graph_dict(graph, hierarchical=True)
+        graph_tensors_from_heterodata(graph, hierarchical=True)
 
 
 def _build_graphlam(datastore, graph_name, use_heterodata):

--- a/tests/test_heterodata.py
+++ b/tests/test_heterodata.py
@@ -1,0 +1,261 @@
+"""Tests for the graph tensor-dict <-> pyg.HeteroData conversion (issue #385).
+
+Two layers of testing:
+
+- unit tests on ``graph_dict_to_heterodata`` / ``heterodata_to_graph_dict``
+  with small hand-built tensor-dicts (no datastore/model needed);
+- a model-level equivalence test showing that a ``GraphLAM`` built with
+  ``use_heterodata=True`` is identical to one built the existing way, both in
+  its parameters/buffers and in its forward output.
+"""
+
+# Standard library
+from pathlib import Path
+
+# Third-party
+import pytest
+import torch
+from torch_geometric.data import HeteroData
+
+# First-party
+from neural_lam.create_graph import create_graph_from_datastore
+from neural_lam.models import GraphLAM
+from neural_lam.utils import (
+    graph_dict_to_heterodata,
+    heterodata_to_graph_dict,
+)
+from neural_lam.utils.buffer_list import BufferList
+from neural_lam.utils.heterodata import (
+    G2M_EDGE_TYPE,
+    GRID_NODE_TYPE,
+    M2G_EDGE_TYPE,
+    M2M_EDGE_TYPE,
+    MESH_NODE_TYPE,
+)
+
+# Keys that ``load_graph`` returns; used to assert the round-trip is exact.
+_GRAPH_DICT_KEYS = {
+    "g2m_edge_index",
+    "m2g_edge_index",
+    "m2m_edge_index",
+    "mesh_up_edge_index",
+    "mesh_down_edge_index",
+    "g2m_features",
+    "m2g_features",
+    "m2m_features",
+    "mesh_up_features",
+    "mesh_down_features",
+    "mesh_static_features",
+}
+
+
+def _flat_graph_dict(edge_feature_dim: int = 3, num_mesh: int = 4):
+    """Build a minimal flat graph tensor-dict for the unit tests.
+
+    Parameters
+    ----------
+    edge_feature_dim : int, default 3
+        Number of edge feature columns (3 for 2D graphs, 4 for 3D).
+    num_mesh : int, default 4
+        Number of mesh nodes.
+
+    Returns
+    -------
+    dict
+        A tensor-dict with the same keys and structure as the flat output of
+        :func:`neural_lam.utils.load_graph`.
+    """
+
+    def edges(n):
+        return torch.tensor([[0, 1, 2], [1, 2, 0]][:2], dtype=torch.int64)[
+            :, :n
+        ]
+
+    def feats(n):
+        return torch.arange(n * edge_feature_dim, dtype=torch.float32).reshape(
+            n, edge_feature_dim
+        )
+
+    return {
+        "g2m_edge_index": torch.tensor(
+            [[0, 1, 2], [0, 1, 2]], dtype=torch.int64
+        ),
+        "m2g_edge_index": torch.tensor(
+            [[0, 1, 2], [3, 4, 5]], dtype=torch.int64
+        ),
+        "m2m_edge_index": edges(3),
+        "mesh_up_edge_index": BufferList([], persistent=False),
+        "mesh_down_edge_index": BufferList([], persistent=False),
+        "g2m_features": feats(3),
+        "m2g_features": feats(3),
+        "m2m_features": feats(3),
+        "mesh_up_features": BufferList([], persistent=False),
+        "mesh_down_features": BufferList([], persistent=False),
+        "mesh_static_features": torch.arange(
+            num_mesh * 2, dtype=torch.float32
+        ).reshape(num_mesh, 2),
+    }
+
+
+def test_builder_flat_structure():
+    """The builder produces the expected node/edge types and tensors."""
+    graph_dict = _flat_graph_dict()
+    num_grid = 6
+    graph = graph_dict_to_heterodata(graph_dict, num_grid_nodes=num_grid)
+
+    assert isinstance(graph, HeteroData)
+    assert set(graph.node_types) == {GRID_NODE_TYPE, MESH_NODE_TYPE}
+    assert set(graph.edge_types) == {
+        G2M_EDGE_TYPE,
+        M2M_EDGE_TYPE,
+        M2G_EDGE_TYPE,
+    }
+
+    # Grid node count comes from the datastore, not from edge indices.
+    assert graph[GRID_NODE_TYPE].num_nodes == num_grid
+    # Mesh node features are stored on .x, unchanged.
+    assert torch.equal(
+        graph[MESH_NODE_TYPE].x, graph_dict["mesh_static_features"]
+    )
+
+    # Each component maps to the right typed edge, with identical tensors.
+    for edge_type, ei_key, ef_key in (
+        (G2M_EDGE_TYPE, "g2m_edge_index", "g2m_features"),
+        (M2M_EDGE_TYPE, "m2m_edge_index", "m2m_features"),
+        (M2G_EDGE_TYPE, "m2g_edge_index", "m2g_features"),
+    ):
+        assert torch.equal(graph[edge_type].edge_index, graph_dict[ei_key])
+        assert torch.equal(graph[edge_type].edge_attr, graph_dict[ef_key])
+
+
+def test_builder_roundtrip_is_exact():
+    """dict -> HeteroData -> dict reproduces the original tensor-dict."""
+    graph_dict = _flat_graph_dict()
+    graph = graph_dict_to_heterodata(graph_dict, num_grid_nodes=6)
+    restored = heterodata_to_graph_dict(graph)
+
+    assert set(restored.keys()) == _GRAPH_DICT_KEYS
+    for key in _GRAPH_DICT_KEYS:
+        original = graph_dict[key]
+        if isinstance(original, torch.Tensor):
+            assert torch.equal(restored[key], original), key
+        else:
+            # The unused hierarchical entries stay empty BufferLists.
+            assert isinstance(restored[key], BufferList), key
+            assert len(restored[key]) == 0, key
+
+
+def test_builder_variable_edge_feature_dim():
+    """Edge feature width is not hardcoded (e.g. 4 cols for 3D graphs)."""
+    graph_dict = _flat_graph_dict(edge_feature_dim=4)
+    graph = graph_dict_to_heterodata(graph_dict, num_grid_nodes=6)
+    assert graph[G2M_EDGE_TYPE].edge_attr.shape[1] == 4
+    assert graph[M2M_EDGE_TYPE].edge_attr.shape[1] == 4
+
+
+def test_builder_grid_count_not_inferred_from_edges():
+    """num_grid_nodes is taken from the argument, not from edge maxima."""
+    graph_dict = _flat_graph_dict()
+    # 100 is far larger than any index present in the edge tensors.
+    graph = graph_dict_to_heterodata(graph_dict, num_grid_nodes=100)
+    assert graph[GRID_NODE_TYPE].num_nodes == 100
+
+
+def test_builder_rejects_hierarchical():
+    """Hierarchical graphs are explicitly not supported yet."""
+    graph_dict = _flat_graph_dict()
+    with pytest.raises(NotImplementedError):
+        graph_dict_to_heterodata(
+            graph_dict, num_grid_nodes=6, hierarchical=True
+        )
+    graph = graph_dict_to_heterodata(graph_dict, num_grid_nodes=6)
+    with pytest.raises(NotImplementedError):
+        heterodata_to_graph_dict(graph, hierarchical=True)
+
+
+def _build_graphlam(datastore, graph_name, use_heterodata):
+    """Construct a small GraphLAM with a fixed seed for equivalence tests."""
+    torch.manual_seed(0)
+    return GraphLAM(
+        datastore=datastore,
+        graph_name=graph_name,
+        hidden_dim=4,
+        hidden_layers=1,
+        processor_layers=1,
+        mesh_aggr="sum",
+        num_past_forcing_steps=0,
+        num_future_forcing_steps=0,
+        output_std=False,
+        use_heterodata=use_heterodata,
+    )
+
+
+def test_graphlam_heterodata_equivalence(tmp_path):
+    """GraphLAM(use_heterodata=True) is identical to the dict-based model.
+
+    Directly addresses the issue #385 requirement that training proceed
+    identically with the existing and the new HeteroData datastructure:
+    identical parameters, identical graph buffers, and identical forward
+    output for the same inputs.
+    """
+    # First-party
+    from tests.dummy_datastore import DummyDatastore
+
+    datastore = DummyDatastore()
+    graph_name = "1level"
+    graph_dir_path = Path(datastore.root_path) / "graph" / graph_name
+    if not graph_dir_path.exists():
+        create_graph_from_datastore(
+            datastore=datastore,
+            output_root_path=str(graph_dir_path),
+            n_max_levels=1,
+        )
+
+    model_dict = _build_graphlam(datastore, graph_name, use_heterodata=False)
+    model_hd = _build_graphlam(datastore, graph_name, use_heterodata=True)
+
+    # The HeteroData model exposes the graph as a HeteroData object.
+    assert isinstance(model_hd.graph, HeteroData)
+    assert not hasattr(model_dict, "graph")
+
+    # Identical parameters.
+    params_dict = dict(model_dict.named_parameters())
+    params_hd = dict(model_hd.named_parameters())
+    assert params_dict.keys() == params_hd.keys()
+    for name in params_dict:
+        assert torch.equal(params_dict[name], params_hd[name]), name
+
+    # Identical graph buffers (edge indices + features + mesh features).
+    for name in (
+        "g2m_edge_index",
+        "m2g_edge_index",
+        "m2m_edge_index",
+        "g2m_features",
+        "m2g_features",
+        "m2m_features",
+        "mesh_static_features",
+    ):
+        assert torch.equal(
+            getattr(model_dict, name), getattr(model_hd, name)
+        ), name
+
+    # Identical forward output for the same inputs.
+    num_grid = model_dict.num_grid_nodes
+    d_state = model_dict.grid_output_dim
+    forcing_dim = (
+        model_dict.grid_input_dim
+        - 2 * d_state
+        - (model_dict.grid_static_features.shape[1])
+    )
+    torch.manual_seed(1)
+    prev_state = torch.randn(1, num_grid, d_state)
+    prev_prev_state = torch.randn(1, num_grid, d_state)
+    forcing = torch.randn(1, num_grid, max(forcing_dim, 0))
+
+    model_dict.eval()
+    model_hd.eval()
+    with torch.no_grad():
+        out_dict, _ = model_dict(prev_state, prev_prev_state, forcing)
+        out_hd, _ = model_hd(prev_state, prev_prev_state, forcing)
+
+    assert torch.equal(out_dict, out_hd)

--- a/tests/test_heterodata.py
+++ b/tests/test_heterodata.py
@@ -23,6 +23,7 @@ from neural_lam.models import GraphLAM
 from neural_lam.utils import (
     graph_dict_to_heterodata,
     graph_tensors_from_heterodata,
+    load_and_register_graph,
 )
 from neural_lam.utils.buffer_list import BufferList
 from neural_lam.utils.heterodata import (
@@ -171,6 +172,37 @@ def test_builder_rejects_hierarchical():
     graph = graph_dict_to_heterodata(graph_dict, num_grid_nodes=6)
     with pytest.raises(NotImplementedError):
         graph_tensors_from_heterodata(graph, hierarchical=True)
+
+
+def test_load_and_register_graph_rejects_hierarchical():
+    """A hierarchical graph cannot be loaded as HeteroData yet.
+
+    The rejection has to happen in ``load_and_register_graph``, since that is
+    where the graph is loaded and the ``HeteroData`` object is built, and it
+    is only there that the graph is known to be hierarchical.
+    """
+    # First-party
+    from tests.dummy_datastore import DummyDatastore
+
+    datastore = DummyDatastore()
+    graph_name = "hierarchical_rejected"
+    graph_dir_path = Path(datastore.root_path) / "graph" / graph_name
+    if not graph_dir_path.exists():
+        create_graph_from_datastore(
+            datastore=datastore,
+            output_root_path=str(graph_dir_path),
+            n_max_levels=3,
+            hierarchical=True,
+        )
+
+    with pytest.raises(NotImplementedError, match="non-hierarchical"):
+        load_and_register_graph(
+            torch.nn.Module(),
+            datastore,
+            graph_name,
+            mesh_node_features_scaling=1.0,
+            use_heterodata=True,
+        )
 
 
 def _build_graphlam(datastore, graph_name, use_heterodata):

--- a/tests/test_heterodata.py
+++ b/tests/test_heterodata.py
@@ -251,6 +251,9 @@ def test_graphlam_heterodata_equivalence(tmp_path):
     assert isinstance(model_hd.graph, HeteroData)
     assert not hasattr(model_dict, "graph")
 
+    # The graph is a view of the model's own tensors, not a second copy.
+    assert model_hd.graph[G2M_EDGE_TYPE].edge_attr is model_hd.g2m_features
+
     # Identical parameters.
     params_dict = dict(model_dict.named_parameters())
     params_hd = dict(model_hd.named_parameters())
@@ -271,6 +274,17 @@ def test_graphlam_heterodata_equivalence(tmp_path):
         assert torch.equal(
             getattr(model_dict, name), getattr(model_hd, name)
         ), name
+
+    # Moving the model must not leave the graph behind: a stored HeteroData
+    # attribute would not be touched by nn.Module._apply and would keep
+    # referring to the pre-move tensors.
+    model_hd.to(torch.float64)
+    assert (
+        model_hd.graph[G2M_EDGE_TYPE].edge_attr.dtype
+        == model_hd.g2m_features.dtype
+    )
+    assert model_hd.graph[MESH_NODE_TYPE].x.dtype == torch.float64
+    model_hd.to(torch.float32)
 
     # Identical forward output for the same inputs.
     num_grid = model_dict.num_grid_nodes

--- a/tests/test_heterodata.py
+++ b/tests/test_heterodata.py
@@ -195,8 +195,9 @@ def test_graphlam_heterodata_equivalence(tmp_path):
 
     Directly addresses the issue #385 requirement that training proceed
     identically with the existing and the new HeteroData datastructure:
-    identical parameters, identical graph buffers, and identical forward
-    output for the same inputs.
+    identical parameters, identical graph buffers, identical forward output
+    for the same inputs, and, when trained with the same optimizer steps,
+    identical per-step losses and identical weights afterwards.
     """
     # First-party
     from tests.dummy_datastore import DummyDatastore
@@ -259,3 +260,27 @@ def test_graphlam_heterodata_equivalence(tmp_path):
         out_hd, _ = model_hd(prev_state, prev_prev_state, forcing)
 
     assert torch.equal(out_dict, out_hd)
+
+    # Training proceeds identically: running the same optimizer steps on both
+    # models yields identical losses at every step and identical weights
+    # afterwards.
+    model_dict.train()
+    model_hd.train()
+    target = torch.randn(1, num_grid, d_state)
+    opt_dict = torch.optim.SGD(model_dict.parameters(), lr=0.1)
+    opt_hd = torch.optim.SGD(model_hd.parameters(), lr=0.1)
+    for _ in range(3):
+        step_losses = []
+        for model, optimizer in ((model_dict, opt_dict), (model_hd, opt_hd)):
+            optimizer.zero_grad()
+            pred, _ = model(prev_state, prev_prev_state, forcing)
+            loss = torch.nn.functional.mse_loss(pred, target)
+            loss.backward()
+            optimizer.step()
+            step_losses.append(loss)
+        assert torch.equal(step_losses[0], step_losses[1])
+
+    trained_dict = dict(model_dict.named_parameters())
+    trained_hd = dict(model_hd.named_parameters())
+    for name in trained_dict:
+        assert torch.equal(trained_dict[name], trained_hd[name]), name


### PR DESCRIPTION

First step of the HeteroData migration (#385), scoped to **flat** (non-hierarchical) graphs.

- Adds `neural_lam.utils.heterodata` with `graph_dict_to_heterodata` and its inverse `heterodata_to_graph_dict`. Grid nodes are the `grid` node type and mesh nodes the `mesh` node type, matching the terminology used throughout neural-lam (`grid_static_features`, `mesh_static_features`, `g2m`/`m2m`/`m2g`); `g2m`/`m2m`/`m2g` become typed edges. The grid node count is taken from the datastore rather than inferred from edge indices, and the edge-feature width is read dynamically (3 for 2D, 4 for 3D). The node/edge-type names are module-level constants; the reference implementations linked from the issue (`leifdenby/weatherduck`, `matschreiner/equicast`) use `data`/`hidden` - happy to switch if preferred.
- Wires into `BaseGraphModel` behind a `use_heterodata` flag (default `False`): when enabled the graph is represented as a `HeteroData` object and the model's graph tensors are taken from it. The extracted tensors are identical to the dict ones, so the model builds and trains identically either way, and existing checkpoints remain compatible.
- Threads the flag through `GraphLAM`.

Hierarchical (HiLAM) support is deliberately left as a follow-up - there is an open question on #385 about how to represent mesh levels as node/edge types.

## Issue Link

Part of #385 (first implementation step; the design discussion and hierarchical follow-up remain open).

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.