### PR TITLE
Exclude boundary nodes from test_step spatial loss maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Exclude boundary nodes from the spatial loss maps computed in `test_step`, so the plotted loss maps and the saved `mean_spatial_loss.pt` cover the interior only, consistent with every other loss and metric call in `ForecasterModule` [\#720](https://github.com/mllam/neural-lam/pull/720) @NoiceHax
+- Exclude boundary nodes from the spatial loss maps computed in `test_step`, so the plotted loss maps and the saved `mean_spatial_loss.pt` cover the interior only, consistent with every other loss and metric call in `ForecasterModule` [\#720](https://github.com/mllam/neural-lam/pull/720) @RajdeepKushwaha5 @NoiceHax
 
 - Fix `RuntimeError` in `HiLAMParallel` forward pass on hierarchical graphs by offsetting edge indices into the global mesh node index space ([#679](https://github.com/mllam/neural-lam/issues/679))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Exclude boundary nodes from the spatial loss maps computed in `test_step`, so the plotted loss maps and the saved `mean_spatial_loss.pt` cover the interior only, consistent with every other loss and metric call in `ForecasterModule` [\#720](https://github.com/mllam/neural-lam/pull/720) @NoiceHax
+
 - Fix `RuntimeError` in `HiLAMParallel` forward pass on hierarchical graphs by offsetting edge indices into the global mesh node index space ([#679](https://github.com/mllam/neural-lam/issues/679))
 
 - Fix `IndexError` in HiLAM forward pass by offsetting grid nodes in `zero_index_g2m`/`zero_index_m2g` by the total mesh-node count across all levels ([#642](https://github.com/mllam/neural-lam/issues/642)) @Sir-Sloth-The-Lazy

--- a/neural_lam/models/module.py
+++ b/neural_lam/models/module.py
@@ -611,6 +611,11 @@ class ForecasterModule(pl.LightningModule):
         spatial_loss = self.loss(
             prediction, target_states, pred_std, average_grid=False
         )
+        # Exclude boundary nodes, consistent with the loss used in
+        # training/validation. NaN-mask in place so the tensor keeps its
+        # (B, pred_steps, num_grid_nodes) shape for downstream plotting,
+        # and is reduced with `torch.nanmean` in `on_test_epoch_end`.
+        spatial_loss[..., ~self.interior_mask_bool] = float("nan")
         log_spatial_losses = spatial_loss[
             :,
             [
@@ -935,7 +940,8 @@ class ForecasterModule(pl.LightningModule):
             torch.cat(self.spatial_loss_maps, dim=0)
         )
         if self.trainer.is_global_zero:
-            mean_spatial_loss = torch.mean(spatial_loss_tensor, dim=0)
+            # `nanmean` because boundary nodes are NaN-masked in `test_step`
+            mean_spatial_loss = torch.nanmean(spatial_loss_tensor, dim=0)
 
             loss_map_figs = [
                 vis.plot_spatial_error(

--- a/neural_lam/models/module.py
+++ b/neural_lam/models/module.py
@@ -611,10 +611,6 @@ class ForecasterModule(pl.LightningModule):
         spatial_loss = self.loss(
             prediction, target_states, pred_std, average_grid=False
         )
-        # Exclude boundary nodes, consistent with the loss used in
-        # training/validation. NaN-mask in place so the tensor keeps its
-        # (B, pred_steps, num_grid_nodes) shape for downstream plotting,
-        # and is reduced with `torch.nanmean` in `on_test_epoch_end`.
         spatial_loss[..., ~self.interior_mask_bool] = float("nan")
         log_spatial_losses = spatial_loss[
             :,

--- a/tests/dummy_datastore.py
+++ b/tests/dummy_datastore.py
@@ -765,3 +765,19 @@ class EnsembleDummyDatastore(BaseDatastore):
     @property
     def state_feature_weights_values(self) -> list[float]:
         return [1.0]
+
+
+def set_framed_boundary(
+    datastore: DummyDatastore, width: int = 1
+) -> np.ndarray:
+    """Replace the random boundary mask with a frame of `width` cells."""
+    shape = (datastore.grid_shape_state.x, datastore.grid_shape_state.y)
+    mask = np.ones(shape, dtype=int)
+    mask[width:-width, width:-width] = 0
+    # `grid_index` is the stacked ("x", "y") dimension, so a C-order flatten
+    # of an (x, y) array lines up with it.
+    datastore.ds["boundary_mask"] = xr.DataArray(
+        mask.reshape(-1), dims=["grid_index"]
+    )
+    datastore.__dict__.pop("boundary_mask", None)  # bust the cached_property
+    return mask

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,15 +1,12 @@
 # Standard library
 import warnings
-from functools import cached_property
 from pathlib import Path
 
 # Third-party
-import numpy as np
 import pytest
 import pytorch_lightning as pl
 import torch
 import wandb
-import xarray as xr
 
 # First-party
 from neural_lam import config as nlconfig
@@ -19,7 +16,7 @@ from neural_lam.datastore.base import BaseRegularGridDatastore
 from neural_lam.models import ARForecaster, ForecasterModule, GraphLAM
 from neural_lam.weather_dataset import WeatherDataModule
 from tests.conftest import init_datastore_example
-from tests.dummy_datastore import DummyDatastore
+from tests.dummy_datastore import DummyDatastore, set_framed_boundary
 
 # Model architecture defaults for tests
 GRAPH = "1level"
@@ -233,27 +230,7 @@ def test_all_gather_cat_multi_device_simulation():
     )
 
 
-class _FramedBoundaryDummyDatastore(DummyDatastore):
-    """`DummyDatastore` with a deterministic boundary mask.
-
-    The base class draws its mask from an unseeded `np.random.choice`, which
-    is fine for smoke tests but cannot be used to assert exact NaN positions.
-    Here the boundary is the one-cell frame around the edge of the domain.
-    """
-
-    @cached_property
-    def boundary_mask(self) -> xr.DataArray:
-        n_points_1d = int(np.sqrt(self.num_grid_points))
-        mask_2d = np.zeros((n_points_1d, n_points_1d), dtype=int)
-        mask_2d[0, :] = 1
-        mask_2d[-1, :] = 1
-        mask_2d[:, 0] = 1
-        mask_2d[:, -1] = 1
-        # `grid_index` is the stacked ("x", "y") dimension, so a C-order
-        # flatten of an (x, y) array lines up with it.
-        return xr.DataArray(mask_2d.reshape(-1), dims=["grid_index"])
-
-
+@pytest.mark.slow
 def test_test_step_excludes_boundary_from_spatial_loss(tmp_path):
     """
     Regression test for issue #569.
@@ -268,7 +245,8 @@ def test_test_step_excludes_boundary_from_spatial_loss(tmp_path):
     """
     # 20x20 is the smallest grid `create_graph_from_datastore` still builds a
     # `1level` mesh for.
-    datastore = _FramedBoundaryDummyDatastore(n_grid_points=400, n_timesteps=10)
+    datastore = DummyDatastore(n_grid_points=400, n_timesteps=10)
+    set_framed_boundary(datastore)
 
     graph_dir_path = Path(datastore.root_path) / "graph" / GRAPH
     if not graph_dir_path.exists():

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,21 +1,25 @@
 # Standard library
 import warnings
+from functools import cached_property
 from pathlib import Path
 
 # Third-party
+import numpy as np
 import pytest
 import pytorch_lightning as pl
 import torch
 import wandb
+import xarray as xr
 
 # First-party
 from neural_lam import config as nlconfig
 from neural_lam.create_graph import create_graph_from_datastore
 from neural_lam.datastore import DATASTORES
 from neural_lam.datastore.base import BaseRegularGridDatastore
-from neural_lam.models import ForecasterModule
+from neural_lam.models import ARForecaster, ForecasterModule, GraphLAM
 from neural_lam.weather_dataset import WeatherDataModule
 from tests.conftest import init_datastore_example
+from tests.dummy_datastore import DummyDatastore
 
 # Model architecture defaults for tests
 GRAPH = "1level"
@@ -227,3 +231,115 @@ def test_all_gather_cat_multi_device_simulation():
         "all_gather_cat produced incorrectly ordered/combined values "
         "on multi-device simulation"
     )
+
+
+class _FramedBoundaryDummyDatastore(DummyDatastore):
+    """`DummyDatastore` with a deterministic boundary mask.
+
+    The base class draws its mask from an unseeded `np.random.choice`, which
+    is fine for smoke tests but cannot be used to assert exact NaN positions.
+    Here the boundary is the one-cell frame around the edge of the domain.
+    """
+
+    @cached_property
+    def boundary_mask(self) -> xr.DataArray:
+        n_points_1d = int(np.sqrt(self.num_grid_points))
+        mask_2d = np.zeros((n_points_1d, n_points_1d), dtype=int)
+        mask_2d[0, :] = 1
+        mask_2d[-1, :] = 1
+        mask_2d[:, 0] = 1
+        mask_2d[:, -1] = 1
+        # `grid_index` is the stacked ("x", "y") dimension, so a C-order
+        # flatten of an (x, y) array lines up with it.
+        return xr.DataArray(mask_2d.reshape(-1), dims=["grid_index"])
+
+
+def test_test_step_excludes_boundary_from_spatial_loss(tmp_path):
+    """
+    Regression test for issue #569.
+
+    `test_step` built its spatial loss map over every grid node, while every
+    other loss and metric call in the module restricts itself to the interior
+    via `interior_mask_bool`. Boundary nodes therefore leaked into the plotted
+    loss maps and into the saved `mean_spatial_loss.pt`.
+
+    Run `trainer.test()` end to end on a datastore with a known boundary mask
+    and check that the saved map is NaN on the boundary and finite inside.
+    """
+    # 20x20 is the smallest grid `create_graph_from_datastore` still builds a
+    # `1level` mesh for.
+    datastore = _FramedBoundaryDummyDatastore(n_grid_points=400, n_timesteps=10)
+
+    graph_dir_path = Path(datastore.root_path) / "graph" / GRAPH
+    if not graph_dir_path.exists():
+        create_graph_from_datastore(
+            datastore=datastore,
+            output_root_path=str(graph_dir_path),
+            n_max_levels=1,
+        )
+
+    config = nlconfig.NeuralLAMConfig(
+        datastore=nlconfig.DatastoreSelection(
+            kind=datastore.SHORT_NAME,
+            config_path=datastore.root_path,
+        ),
+    )
+
+    predictor = GraphLAM(
+        datastore=datastore,
+        graph_name=GRAPH,
+        hidden_dim=HIDDEN_DIM,
+        hidden_layers=HIDDEN_LAYERS,
+        processor_layers=1,
+        mesh_aggr=MESH_AGGR,
+        num_past_forcing_steps=0,
+        num_future_forcing_steps=0,
+        output_std=False,
+        output_clamping_lower=config.training.output_clamping.lower,
+        output_clamping_upper=config.training.output_clamping.upper,
+    )
+    model = ForecasterModule(
+        forecaster=ARForecaster(predictor, datastore),
+        config=config,
+        datastore=datastore,
+        loss="mse",
+        lr=1.0e-3,
+        restore_opt=False,
+        n_example_pred=0,  # skip example plotting, not what is under test
+        val_steps_to_log=[1],
+    )
+
+    data_module = WeatherDataModule(
+        datastore=datastore,
+        ar_steps_train=1,
+        ar_steps_eval=2,
+        batch_size=1,
+        num_workers=0,
+        num_past_forcing_steps=0,
+        num_future_forcing_steps=0,
+    )
+
+    trainer = pl.Trainer(
+        accelerator="cpu",
+        devices=1,
+        logger=pl.loggers.CSVLogger(save_dir=str(tmp_path)),
+        log_every_n_steps=1,
+        enable_checkpointing=False,
+    )
+    trainer.test(model=model, datamodule=data_module)
+
+    saved_path = Path(trainer.logger.save_dir) / "mean_spatial_loss.pt"
+    assert saved_path.exists(), "test epoch did not save a spatial loss map"
+
+    # (len(val_steps_to_log), num_grid_nodes)
+    mean_spatial_loss = torch.load(saved_path, weights_only=True)
+    assert mean_spatial_loss.shape == (1, datastore.num_grid_points)
+
+    boundary = torch.tensor(datastore.boundary_mask.values, dtype=torch.bool)
+    assert torch.isnan(mean_spatial_loss[:, boundary]).all(), (
+        "boundary nodes must be excluded from the test spatial loss map, "
+        "consistent with every other loss call in the module"
+    )
+    assert torch.isfinite(
+        mean_spatial_loss[:, ~boundary]
+    ).all(), "interior nodes must keep finite loss values"


### PR DESCRIPTION
## Describe your changes

`test_step` built its spatial loss map over the whole grid, while every other
loss and metric call in `ForecasterModule` restricts itself to the interior via
`interior_mask_bool`. `ARForecaster` overwrites the boundary nodes with the true
boundary state, so their loss is always ~0, and those zeros were dragging down
the saved `mean_spatial_loss.pt` and flattening the colour range of the plotted
loss maps.

This NaN-masks the boundary right after the loss call and reduces with
`torch.nanmean` in `on_test_epoch_end`. Passing `mask=self.interior_mask_bool`
into `self.loss` is not an option: `metrics.mask_and_reduce_metric`
index-selects with `metric_entry_vals[..., mask, :]`, which shrinks the grid
dimension and breaks the shape `vis.plot_spatial_error` reshapes back onto the
grid. `vis.py` needs no change, it already uses `np.nanmin`/`np.nanmax` and
matplotlib draws NaN cells transparent.

The fix is @RajdeepKushwaha5's from #568, following @sadamov's review there.
#568 edits `neural_lam/models/ar_model.py`, which no longer exists after the
`ForecasterModule` split in #208, so it cannot be rebased onto main. The new
test is the first coverage of `test_step` / `on_test_epoch_end`. It fails on
main and passes here.

No new dependencies. Written with help from Claude Code.

## Issue Link

closes #569

## Type of change

- [x] ðŸ› Bug fix (non-breaking change that fixes an issue)
- [ ] âœ¨ New feature (non-breaking change that adds functionality)
- [ ] ðŸ’¥ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ðŸ“– Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes - not needed, nothing user-facing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [x] PR is up to date with the base branch
- [x] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.