### PR TITLE
Indicate edge direction with arrowheads in create_graph.plot_graph

### DIFF
--- a/neural_lam/create_graph.py
+++ b/neural_lam/create_graph.py
@@ -51,10 +51,10 @@ def plot_graph(
     # higher levels in hierarchy
     edge_index = edge_index - edge_index.min()
 
-    if pyg.utils.is_undirected(edge_index):
+    is_undirected = pyg.utils.is_undirected(edge_index)
+    if is_undirected:
         # Keep only 1 direction of edge_index
         edge_index = edge_index[:, edge_index[0] < edge_index[1]]  # (2, M/2)
-    # TODO: indicate direction of directed edges
 
     # Move all to cpu and numpy, compute (in)-degrees
     degrees = (
@@ -66,12 +66,29 @@ def plot_graph(
     # Plot edges
     from_pos = pos[edge_index[0]]  # (M/2, 2)
     to_pos = pos[edge_index[1]]  # (M/2, 2)
-    edge_lines = np.stack((from_pos, to_pos), axis=1)
-    axis.add_collection(
-        matplotlib.collections.LineCollection(
-            edge_lines, lw=0.4, colors="black", zorder=1
+    if is_undirected:
+        edge_lines = np.stack((from_pos, to_pos), axis=1)
+        axis.add_collection(
+            matplotlib.collections.LineCollection(
+                edge_lines, lw=0.4, colors="black", zorder=1
+            )
         )
-    )
+    else:
+        # Arrowheads make edge direction visible for directed graphs
+        axis.quiver(
+            from_pos[:, 0],
+            from_pos[:, 1],
+            to_pos[:, 0] - from_pos[:, 0],
+            to_pos[:, 1] - from_pos[:, 1],
+            angles="xy",
+            scale_units="xy",
+            scale=1,
+            width=0.002,
+            headwidth=9,
+            headlength=10,
+            color="black",
+            zorder=1,
+        )
 
     # Plot nodes
     node_scatter = axis.scatter(

--- a/tests/test_create_graph_plot.py
+++ b/tests/test_create_graph_plot.py
@@ -1,0 +1,50 @@
+# Standard library
+from typing import Iterator
+
+# Third-party
+import matplotlib.collections
+import matplotlib.pyplot as plt
+import matplotlib.quiver
+import pytest
+import torch
+from torch_geometric.data import Data
+
+# First-party
+from neural_lam.create_graph import plot_graph
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_agg_backend() -> None:
+    """Use non-interactive backend for all plotting tests."""
+    plt.switch_backend("Agg")
+
+
+@pytest.fixture(autouse=True)
+def close_all_figures_after_test() -> Iterator[None]:
+    """Ensure test-created matplotlib figures are always cleaned up."""
+    yield
+    plt.close("all")
+
+
+def test_directed_graph_uses_quiver_for_arrowheads() -> None:
+    """Directed edges should be drawn with arrowheads, not plain lines."""
+    pos = torch.tensor([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]])
+    edge_index = torch.tensor([[0, 1], [1, 2]]).T
+    graph = Data(edge_index=edge_index, pos=pos)
+
+    _, axis = plot_graph(graph)
+
+    assert axis.findobj(matplotlib.quiver.Quiver)
+    assert not axis.findobj(matplotlib.collections.LineCollection)
+
+
+def test_undirected_graph_uses_line_collection() -> None:
+    """Undirected edges keep the existing plain-line rendering."""
+    pos = torch.tensor([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]])
+    edge_index = torch.tensor([[0, 1], [1, 0], [1, 2], [2, 1]]).T
+    graph = Data(edge_index=edge_index, pos=pos)
+
+    _, axis = plot_graph(graph)
+
+    assert axis.findobj(matplotlib.collections.LineCollection)
+    assert not axis.findobj(matplotlib.quiver.Quiver)


### PR DESCRIPTION
## Describe your changes

`plot_graph` in `create_graph.py` had a TODO: directed edges (g2m, m2g) rendered as plain lines, identical to undirected edges, giving no visual indication of direction. Directed edges now draw with `axis.quiver` arrowheads; undirected edges keep the existing `LineCollection` behavior unchanged.

Note: #381 already covers this and was marked completed, but its fix (#383) was closed without merging, so the TODO was still present on `main`. This is a fresh, simpler implementation (a single `quiver()` call with fixed styling, no per-graph-size heuristics).

## Issue Link

closes #381

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.
