### PR TITLE
Fix hardcoded state_feature coordinate in create_dataarray_from_tensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set `workers=True` in `seed_everything` to properly seed DataLoader workers, ensuring uncorrelated random states across processes when `num_workers > 0` [\#716](https://github.com/mllam/neural-lam/pull/716) @GiGiKoneti
 
+- Fix `WeatherDataset.create_dataarray_from_tensor` hardcoding the `state_feature` coordinate regardless of `category`, so `category="forcing"` raised `AttributeError` instead of using `forcing_feature` [\#726](https://github.com/mllam/neural-lam/pull/726) @AshNicolus
+
 - Fix `graph_lam` training and checkpoint reloads crashing on hierarchical-only GNN options, by routing both call sites through a `build_predictor` helper that only passes `mesh_up_gnn_type` / `mesh_down_gnn_type` to `BaseHiGraphModel` subclasses. [\#688](https://github.com/mllam/neural-lam/pull/688) @gitcommit90
 
 - Build the training logger config from the public `datastore.config` accessor instead of the MDP-specific private `_config` attribute, so any datastore implementing `BaseDatastore` can be driven through the training entry point without raising `AttributeError` [\#723](https://github.com/mllam/neural-lam/pull/723) @zakirkg

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -575,7 +575,7 @@ class WeatherDataset(torch.utils.data.Dataset):
         time : datetime.datetime or list[datetime.datetime]
             The time or times of the tensor.
         category : str
-            The category of the tensor, either "state", "forcing" or "static".
+            The category of the tensor, either "state" or "forcing".
 
         Returns
         -------
@@ -613,10 +613,10 @@ class WeatherDataset(torch.utils.data.Dataset):
 
         da_datastore_state = getattr(self, f"da_{category}")
         da_grid_index = da_datastore_state.grid_index
-        da_state_feature = da_datastore_state.state_feature
+        da_category_feature = da_datastore_state[f"{category}_feature"]
 
         coords = {
-            f"{category}_feature": da_state_feature,
+            f"{category}_feature": da_category_feature,
             "grid_index": da_grid_index,
         }
         if add_time_as_dim:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -156,6 +156,25 @@ def test_dataset_item_create_dataarray_from_tensor(datastore_name):
         )
 
 
+def test_create_dataarray_from_tensor_forcing_category():
+    """category="forcing" must use the forcing_feature coordinate, not the
+    state_feature one hardcoded for the "state" category."""
+    datastore = DummyDatastore()
+    dataset = WeatherDataset(datastore=datastore, split="train")
+
+    tensor = torch.tensor(dataset.da_forcing.isel(time=0).values)
+    da = dataset.create_dataarray_from_tensor(
+        tensor=tensor,
+        time=dataset.da_forcing.time.values[0],
+        category="forcing",
+    )
+
+    assert "forcing_feature" in da.coords
+    np.testing.assert_equal(
+        da.forcing_feature.values, dataset.da_forcing.forcing_feature.values
+    )
+
+
 @pytest.mark.parametrize("split", ["train", "val", "test"])
 @pytest.mark.parametrize("datastore_name", DATASTORES.keys())
 def test_single_batch(datastore_name, split):


### PR DESCRIPTION
## Describe your changes

`WeatherDataset.create_dataarray_from_tensor` builds its coordinate dict from `da_datastore_state.state_feature`, regardless of the `category` argument. Calling it with `category="forcing"` therefore raises `AttributeError: 'DataArray' object has no attribute 'state_feature'` instead of using the `forcing_feature` coordinate that `self.da_forcing` actually has. Fixed by looking up `da_datastore_state[f"{category}_feature"]` instead.

`category="static"` was documented as supported but was never actually wired up (there is no `self.da_static` anywhere in `WeatherDataset`), so it would fail even earlier with a plain `AttributeError` on the `getattr` call. Rather than half-implement static support in this PR, I corrected the docstring to only document `"state"` and `"forcing"` as valid categories, matching what the class actually implements. Happy to open a separate issue for static support if that's wanted.

Added a regression test (`test_create_dataarray_from_tensor_forcing_category` in `tests/test_datasets.py`) using `DummyDatastore`, verified it fails with the original `AttributeError` before the fix and passes after.

Note on #536: PR #556 was closed without merging and addressed a different method (`__getitem__` dimension transposing), not this coordinate bug, so the issue was still open and unfixed.

## Issue Link

closes #536

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.