### PR TITLE
Add bias (mean signed error) metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased](https://github.com/mllam/neural-lam/compare/v0.6.0...HEAD)
 
 ### Added
+- Add `bias` (mean signed error) metric, computed and logged automatically during `--eval test` alongside `mse`/`mae` [\#737](https://github.com/mllam/neural-lam/pull/737) @AshNicolus
+
 - Add latent encoder/decoder modules and the `GraphEFM` (hierarchical) / `GraphEFMMultiScale` (flat) step predictors for the Graph-EFM ensemble forecasting model. [\#648](https://github.com/mllam/neural-lam/pull/648) @Sir-Sloth-The-Lazy
 
 - Add `--num_sanity_val_steps` CLI argument to control sanity validation steps before training (#694)

--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -280,6 +280,52 @@ def mae(
     )
 
 
+def bias(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    pred_std: torch.Tensor,
+    mask: torch.Tensor | None = None,
+    average_grid: bool = True,
+    sum_vars: bool = True,
+) -> torch.Tensor:
+    """
+    (Unweighted) Bias, i.e. mean signed error. Positive values indicate the
+    prediction is on average too high, negative too low.
+
+    Parameters
+    ----------
+    pred : torch.Tensor
+        Shape ``(..., N, num_variables)``. Model prediction. ``(...)`` denotes
+        any number of broadcastable batch dimensions, ``N`` is the number
+        of grid nodes, and ``num_variables`` is the number of state variables.
+    target : torch.Tensor
+        Shape ``(..., N, num_variables)``. Ground-truth target. Dims: same as
+        ``pred``.
+    pred_std : torch.Tensor
+        Shape ``(..., N, num_variables)`` or ``(num_variables,)``. Unused;
+        kept for a signature consistent with the other metrics.
+    mask : torch.Tensor or None, optional
+        Shape ``(N,)``. Boolean mask over grid nodes. ``None`` uses all
+        nodes.
+    average_grid : bool, optional
+        If True, average over the grid dimension (default True).
+    sum_vars : bool, optional
+        If True, sum over the variable dimension (default True).
+
+    Returns
+    -------
+    torch.Tensor
+        Reduced metric values. Shape is one of ``(...,)``,
+        ``(..., num_variables)``, ``(..., N)``, or ``(..., N, num_variables)``
+        depending on ``average_grid`` and ``sum_vars``.
+    """
+    entry_bias = pred - target  # (..., num_grid_nodes, num_variables)
+
+    return mask_and_reduce_metric(
+        entry_bias, mask=mask, average_grid=average_grid, sum_vars=sum_vars
+    )
+
+
 def nll(
     pred: torch.Tensor,
     target: torch.Tensor,
@@ -391,6 +437,7 @@ DEFINED_METRICS = {
     "mae": mae,
     "wmse": wmse,
     "wmae": wmae,
+    "bias": bias,
     "nll": nll,
     "crps_gauss": crps_gauss,
 }

--- a/neural_lam/models/module.py
+++ b/neural_lam/models/module.py
@@ -231,6 +231,7 @@ class ForecasterModule(pl.LightningModule):
         self.test_metrics: dict[str, list] = {
             "mse": [],
             "mae": [],
+            "bias": [],
         }
         if self.forecaster.predicts_std:
             self.test_metrics["output_std"] = []  # Treat as metric
@@ -639,7 +640,7 @@ class ForecasterModule(pl.LightningModule):
             hparams.val_steps_to_log  # ty: ignore[unresolved-attribute]
         )
 
-        for metric_name in ("mse", "mae"):
+        for metric_name in ("mse", "mae", "bias"):
             metric_func = metrics.get_metric(metric_name)
             batch_metric_vals = metric_func(
                 prediction,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,30 @@
+# Third-party
+import torch
+
+# First-party
+from neural_lam.metrics import bias, get_metric
+
+
+def test_bias_is_signed_mean_error():
+    pred = torch.tensor([[[2.0, 1.0], [4.0, 1.0]]])
+    target = torch.tensor([[[1.0, 3.0], [1.0, 3.0]]])
+    pred_std = torch.ones_like(pred)
+
+    result = bias(pred, target, pred_std, average_grid=False, sum_vars=False)
+
+    torch.testing.assert_close(result, pred - target)
+
+
+def test_bias_reduction_matches_mean_over_grid_and_sum_over_vars():
+    pred = torch.tensor([[[2.0, 1.0], [4.0, 1.0]]])
+    target = torch.tensor([[[1.0, 3.0], [0.0, 3.0]]])
+    pred_std = torch.ones_like(pred)
+
+    result = bias(pred, target, pred_std)
+
+    expected = torch.mean(pred - target, dim=-2).sum(dim=-1)
+    torch.testing.assert_close(result, expected)
+
+
+def test_bias_registered_as_defined_metric():
+    assert get_metric("bias") is bias


### PR DESCRIPTION
## Describe your changes

`neural_lam/metrics.py` has a tight, mirrored family of magnitude-only error metrics (`mse`/`wmse`, `mae`/`wmae`), all sharing the same signature and the same `mask_and_reduce_metric` reduction helper. Standard NWP/verification practice pairs magnitude metrics like RMSE/MAE with **bias** (mean signed error, `mean(pred - target)`) to detect systematic over/under-forecasting - something RMSE/MAE alone can't reveal, since they can't distinguish a systematic bias from random scatter. `bias` doesn't exist anywhere in the codebase under any name.

Added `bias`, following the exact `mae` signature/reduction pattern (no `pred_std`-weighted variant needed, same as `mae`), registered it in `DEFINED_METRICS`, and added it to `ForecasterModule.test_step`'s existing `("mse", "mae")` auto-eval loop so it's computed and logged during `--eval test` for free, through the already metric-name-agnostic `aggregate_and_plot_metrics`/`create_metric_log_dict` path (verified: the `"mse" in metric_name` sqrt special-case doesn't false-trigger on `"bias"`, and the linear `* state_std` rescale is already the correct treatment for a non-squared metric, same as how `mae` is handled today).

Added `tests/test_metrics.py` with direct unit tests for `bias` (signed-error correctness, reduction behavior, registry lookup). Ran the full `tests/test_training.py` + `tests/test_plotting.py` integration suites (27 tests, excluding network-dependent `mdp` cases) to confirm adding `bias` to the test-metrics loop doesn't break anything - all pass.

## Issue Link

closes #736

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.