### PR TITLE
Add Markdown link checking and a PR-template doc-update reminder

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -2,17 +2,21 @@
 
 # Also verify `#section` anchors resolve, not just that the file exists.
 include_fragments = "full"
-timeout = 20
+
+# Cache results so the whole-tree check stays cheap on repeat runs.
+cache = true
+max_cache_age = "2d"
 
 # Single-quoted TOML literal strings: regex backslashes need no escaping.
 exclude = [
-    # Reachable for humans, but reject automated requests (bot filtering,
-    # link shorteners), so they would fail the check even while working.
+    # Unverifiable over HTTP, so checking them would only add flakiness:
+    # join.slack.com answers 403 for live and dead invites alike, and
+    # kutt.to answers 200 for short links that do not exist.
     '^https://join\.slack\.com/t/ml-lam/shared_invite/',
     '^https://kutt\.to/mllam$',
-    '^https://pyg\.org/?$',
-    # CHANGELOG's auto-generated self-references: ~142 links that always
+    # Times out on automated requests, both the apex domain and www.
+    '^https://(www\.)?pyg\.org/?$',
+    # CHANGELOG's auto-generated self-references: ~147 links that always
     # resolve, and dominate the runtime if re-checked on every commit.
-    # `NNN` is the placeholder in CONTRIBUTING.md's changelog example.
-    '^https://github\.com/mllam/neural-lam/(issues|pull)/(\d+|NNN)/?$',
+    '^https://github\.com/mllam/neural-lam/(issues|pull)/\d+/?$',
 ]

--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,0 +1,18 @@
+# Config for the lychee link checker (see .pre-commit-config.yaml).
+
+# Also verify `#section` anchors resolve, not just that the file exists.
+include_fragments = "full"
+timeout = 20
+
+# Single-quoted TOML literal strings: regex backslashes need no escaping.
+exclude = [
+    # Reachable for humans, but reject automated requests (bot filtering,
+    # link shorteners), so they would fail the check even while working.
+    '^https://join\.slack\.com/t/ml-lam/shared_invite/',
+    '^https://kutt\.to/mllam$',
+    '^https://pyg\.org/?$',
+    # CHANGELOG's auto-generated self-references: ~142 links that always
+    # resolve, and dominate the runtime if re-checked on every commit.
+    # `NNN` is the placeholder in CONTRIBUTING.md's changelog example.
+    '^https://github\.com/mllam/neural-lam/(issues|pull)/(\d+|NNN)/?$',
+]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,8 @@
 - [ ] I have performed a self-review of my code
 - [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
 - [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
-- [ ] I have updated the [README](README.MD) to cover introduced code changes
+- [ ] I have updated the [README](../README.md) to cover introduced code changes
+- [ ] If this PR changes contributor workflow, I've updated CONTRIBUTING.md / AGENTS.md
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
 - [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@
 - [ ] I have performed a self-review of my code
 - [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
 - [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
-- [ ] I have updated the [README](../README.md) to cover introduced code changes
+- [ ] I have updated the README to cover introduced code changes
 - [ ] If this PR changes contributor workflow, I've updated CONTRIBUTING.md / AGENTS.md
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   pre-commit-job:
     runs-on: ubuntu-latest
+    env:
+      SKIP: lychee
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -21,3 +23,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - uses: pre-commit/action@v3.0.1
+
+  link-check-job:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.13"
+    - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: lychee --all-files

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ build/
 *.egg-info/
 
 tests/test_outputs/
+.lycheecache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,9 @@ repos:
     hooks:
       - id: lychee
         description: Check links in Markdown files
-        args: ["--no-progress", "--config", ".github/lychee.toml"]
+        args: ["--no-progress", "--config", ".github/lychee.toml", "--hidden", "."]
         types: [markdown]
+        pass_filenames: false
 
   - repo: https://github.com/psf/black
     rev: 25.11.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,14 @@ repos:
       - id: codespell
         description: Check for spelling errors
 
+  - repo: https://github.com/lycheeverse/lychee
+    rev: lychee-v0.24.2
+    hooks:
+      - id: lychee
+        description: Check links in Markdown files
+        args: ["--no-progress", "--config", ".github/lychee.toml"]
+        types: [markdown]
+
   - repo: https://github.com/psf/black
     rev: 25.11.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Maintenance
 
-- Add a `lychee` pre-commit hook that checks Markdown links and section anchors (configured in `.github/lychee.toml`), add a PR-template checklist item reminding contributors to update `CONTRIBUTING.md` / `AGENTS.md` when they change contributor workflow, and fix the two broken links the new hook surfaced [\#NNN](https://github.com/mllam/neural-lam/pull/NNN) @KumarShivam1908 @beanscg
+- Add a `lychee` pre-commit hook that checks Markdown links and section anchors (configured in `.github/lychee.toml`), add a PR-template checklist item reminding contributors to update `CONTRIBUTING.md` / `AGENTS.md` when they change contributor workflow, and fix the two broken links the new hook surfaced [\#738](https://github.com/mllam/neural-lam/pull/738) @KumarShivam1908
 
 - Rename the `d_mesh_static` mesh-node static-feature dimension to `num_mesh_static_vars` in comments and docstrings, matching the canonical `num_*` naming. [\#695](https://github.com/mllam/neural-lam/pull/695) @uttam12331
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Maintenance
 
+- Add a `lychee` pre-commit hook that checks Markdown links and section anchors (configured in `.github/lychee.toml`), add a PR-template checklist item reminding contributors to update `CONTRIBUTING.md` / `AGENTS.md` when they change contributor workflow, and fix the two broken links the new hook surfaced [\#NNN](https://github.com/mllam/neural-lam/pull/NNN) @KumarShivam1908 @beanscg
+
 - Rename the `d_mesh_static` mesh-node static-feature dimension to `num_mesh_static_vars` in comments and docstrings, matching the canonical `num_*` naming. [\#695](https://github.com/mllam/neural-lam/pull/695) @uttam12331
 
 - Add 100% type-hint coverage across `neural_lam/`, align all type annotations with PEP 585 and PEP 604, and adopt `ty` (astral-sh) for type checking [\#673](https://github.com/mllam/neural-lam/pull/673) @GiGiKoneti

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Maintenance
 
-- Add a `lychee` pre-commit hook that checks Markdown links and section anchors (configured in `.github/lychee.toml`), add a PR-template checklist item reminding contributors to update `CONTRIBUTING.md` / `AGENTS.md` when they change contributor workflow, and fix the two broken links the new hook surfaced [\#738](https://github.com/mllam/neural-lam/pull/738) @KumarShivam1908
+- Add a `lychee` pre-commit hook checking Markdown links and section anchors (config in `.github/lychee.toml`, run once per push in CI) and a PR-template reminder to update `CONTRIBUTING.md` / `AGENTS.md` [\#738](https://github.com/mllam/neural-lam/pull/738) @KumarShivam1908
 
 - Rename the `d_mesh_static` mesh-node static-feature dimension to `num_mesh_static_vars` in comments and docstrings, matching the canonical `num_*` naming. [\#695](https://github.com/mllam/neural-lam/pull/695) @uttam12331
 

--- a/README.md
+++ b/README.md
@@ -601,5 +601,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide: how to op
 
 # Contact
 If you are interested in machine learning models for LAM, have questions about the implementation or ideas for extending it, feel free to get in touch.
-There is an open [mllam slack channel](https://join.slack.com/t/ml-lam/shared_invite/zt-2t112zvm8-Vt6aBvhX7nYa6Kbj_LkCBQ) that anyone can join (after following the link you have to request to join, this is to avoid spam bots).
+There is an open [mllam slack channel](https://kutt.to/mllam) that anyone can join (after following the link you have to request to join, this is to avoid spam bots).
 You can also open a github issue on this page.

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ in neural-lam, are done in a separate package called
 [mllam-data-prep](https://github.com/mllam/mllam-data-prep) rather than in
 neural-lam itself.
 Specifically, the `mllam-data-prep` datastore configuration (for example
-[danra.datastore.yaml](tests/datastore_examples/mdp/danra.datastore.yaml))
+[danra.datastore.yaml](tests/datastore_examples/mdp/danra_100m_winds/danra.datastore.yaml))
 specifies a) what source datasets to read from, b) what variables to select, c)
 what transformations of dimensions and variables to make, d) what statistics to
 calculate (for normalisation) and e) how to split the data into training,


### PR DESCRIPTION
## Describe your changes

Implements the two mechanisms requested in #654.

**1. Markdown link checker in pre-commit**

Adds the `lychee` hook, configured via `.github/lychee.toml`. It validates the three things the issue lists: cross-file references, section anchors (`include_fragments = "full"`, so a renamed heading is caught rather than silently orphaning `AGENTS.md` -> `CONTRIBUTING.md#before-you-push`), and external URLs.

The hook runs with `pass_filenames: false` and `--hidden .`, so any Markdown edit re-checks the whole tree. That is the case worth catching: renaming a heading breaks a link in a file the commit never touched, which per-file checking misses. `--hidden` is required or `.github/` is skipped on traversal. `cache = true` with `max_cache_age = "2d"` keeps the repeat cost at ~0.2s.

The config excludes two sets of links:

- Links no HTTP check can verify: `join.slack.com` answers the same for live and dead invites, and `kutt.to` answers the same for short links that were never created. `pyg.org` times out on automated requests. These are excluded rather than removed, so they keep working in the docs.
- `mllam/neural-lam/(issues|pull)/N` self-references, which are ~150 of CHANGELOG's 162 links, auto-generated and always resolving.

In CI the hook is `SKIP`ped in the Python 3.10-3.14 lint matrix and runs once in a separate `link-check-job`. lychee has no Python dependency, so running it per matrix leg would repeat the same ~78 live requests five times per push and populate five separate binary caches.

**2. PR template reminder**

Adds the checklist item from the issue, verbatim:

```
- [ ] If this PR changes contributor workflow, I've updated CONTRIBUTING.md / AGENTS.md
```

**3. Link fixes surfaced along the way**

- `README.md` linked `tests/datastore_examples/mdp/danra.datastore.yaml`; the file is at `mdp/danra_100m_winds/danra.datastore.yaml`. The hook does not pass on `main` without this.
- The PR template's `[README](README.MD)` link is now plain text. The original 404s on case-sensitive checkouts, and a relative path cannot work either, because GitHub inlines this template into the PR body verbatim without rewriting links.
- `README.md` line 604 hardcoded a Slack invite token while the badge and both `CONTRIBUTING.md` references use `kutt.to/mllam`. The two were already out of sync (`kutt.to` now points at `zt-3tkm6wn34-...`, line 604 had `zt-2t112zvm8-...`), and since the invite is excluded from checking, nothing would have reported it. All Slack references now go through the shortener.

**Dependencies:** none. `lychee` is fetched by pre-commit at the pinned `lychee-v0.24.2` tag; no runtime or `dev` dependency changes.

### Relation to #655

This continues @beanscg's PR #655, which stalled with review feedback outstanding. Both of @sadamov's asks there are applied: the config lives at `.github/lychee.toml` with a matching `--config` path, and the CHANGELOG self-reference exclude is in.

### Verification

- `pre-commit run --all-files`: 17 hooks, 0 failures
- `238 Total, 212 Unique, 78 OK, 0 Errors, 160 Excluded` - confirms the hook is checking, not passing vacuously
- Anchor and file checks confirmed by temporarily introducing a moved file and a renamed anchor in `AGENTS.md`: both reported with file and line
- `--hidden` confirmed necessary: 238 links found with it, 237 without, the difference being `.github/pull_request_template.md`
- `SKIP=lychee pre-commit run --all-files` confirmed to skip only that hook
- Timing: 4.8s cold, ~0.9s warm (lychee itself 213ms); CHANGELOG.md alone is 162 links
- No Python changed by this branch. `pytest tests/test_imports.py tests/test_config.py tests/test_cli.py tests/test_time_slicing.py`: 20 passed

## Issue Link

closes #654

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [x] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [x] I have updated the README to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A: no code paths are added. See Verification above.
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [x] the code is readable
- [x] the code is well tested
- [x] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [x] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [x] PR is up to date with the base branch
- [x] the tests pass
- [x] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [x] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
- Once the PR is ready to be merged, squash commits and merge the PR.
